### PR TITLE
Rename published to publicationDate

### DIFF
--- a/pipeline/src/config/articles.ts
+++ b/pipeline/src/config/articles.ts
@@ -26,7 +26,7 @@ export const articlesMapping = {
             },
           },
         },
-        published: {
+        publicationDate: {
           type: "date",
           format: "date_optional_time",
         },

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -135,7 +135,7 @@ export const transformArticle = (
     },
     query: {
       title: asTitle(data.title),
-      published: new Date(datePublished),
+      publicationDate: new Date(datePublished),
       contributors: queryContributors,
       caption,
       body: queryBody,

--- a/pipeline/src/types/index.ts
+++ b/pipeline/src/types/index.ts
@@ -43,7 +43,7 @@ export type ElasticsearchArticle = {
   display: Article;
   query: {
     title: string;
-    published: Date;
+    publicationDate: Date;
     contributors: string[];
     caption?: string;
     body?: string;


### PR DESCRIPTION
Realised it still had a different name in `query` and `display`, so fixing that.