### PR TITLE
Refactoring ahead of infra

### DIFF
--- a/pipeline/src/config.ts
+++ b/pipeline/src/config.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const environmentSchema = z.object({
+  PIPELINE_DATE: z.string(),
+});
+const environment = environmentSchema.parse(process.env);
+
+const config = {
+  pipelineDate: environment.PIPELINE_DATE,
+};
+
+export type Config = typeof config;
+
+export const getConfig = () => config;

--- a/pipeline/src/handler.ts
+++ b/pipeline/src/handler.ts
@@ -1,10 +1,10 @@
 import { Handler } from "aws-lambda";
+import { from, expand, mergeMap, map, EMPTY } from "rxjs";
 import { ArticlePrismicDocument, Clients } from "./types";
 import { transformArticle } from "./transformers/article";
-import { addIndex, bulkIndexDocuments } from "./helpers/elasticsearch";
+import { ensureIndexExists, bulkIndexDocuments } from "./helpers/elasticsearch";
 import { getPrismicDocuments } from "./helpers/prismic";
-import { from, expand, mergeMap, map, EMPTY } from "rxjs";
-import { observableToStream } from "./helpers/observableToStream";
+import { articles } from "./indices";
 
 type WindowEvent = {
   start?: Date;
@@ -16,7 +16,11 @@ export const createHandler =
   async (event, context) => {
     try {
       // 0. Create index if necessary
-      await addIndex(clients.elastic);
+      await ensureIndexExists(clients.elastic, {
+        index: articles.index,
+        mappings: articles.mapping,
+        settings: articles.settings,
+      });
 
       // 1. Fetches everything from Prismic
       // TODO between event.start and event.end
@@ -35,16 +39,15 @@ export const createHandler =
       );
 
       // // 3. Indexes all of them in ES
-      const count = await bulkIndexDocuments(
+      const result = await bulkIndexDocuments(
         clients.elastic,
-        observableToStream(articleObservable)
+        articles.index,
+        articleObservable
       );
 
-      // on first creation of the index, the number returned isn't relevant and tends to be way lower
-      // than the actual result.
-      // once created though, it does return the correct amount of indexed articles.
-      console.log({ count });
-      return count;
+      console.log(
+        `Finished indexing documents; ${result.successful} successes and ${result.failed.length} failures in ${result.time}ms`
+      );
     } catch (error) {
       // TODO handle this better, what would we want here?
       console.log({ error });

--- a/pipeline/src/indices/articles.ts
+++ b/pipeline/src/indices/articles.ts
@@ -1,6 +1,8 @@
 import { IndicesIndexSettings } from "@elastic/elasticsearch/lib/api/types";
 
-export const articlesMapping = {
+export const index = "articles";
+
+export const mapping = {
   dynamic: "strict",
   properties: {
     id: {
@@ -85,7 +87,7 @@ export const articlesMapping = {
   },
 } as const;
 
-export const articlesSettings = {
+export const settings = {
   analysis: {
     normalizer: {
       keyword_lowercase: {

--- a/pipeline/src/indices/index.ts
+++ b/pipeline/src/indices/index.ts
@@ -1,0 +1,3 @@
+import * as articles from "./articles";
+
+export { articles };

--- a/pipeline/src/lambda.ts
+++ b/pipeline/src/lambda.ts
@@ -5,13 +5,16 @@ import { getElasticClient } from "@weco/content-common/services/elasticsearch";
 import { createHandler } from "./handler";
 import { createPrismicClient } from "./services/prismic";
 import { Handler } from "aws-lambda";
+import { getConfig } from "./config";
+
+const config = getConfig();
 
 // This is a hoop we jump through because we need to create the handler asynchronously
 // (as we're fetching secrets) but we don't want to do that for every call, just for
 // every cold start of the Lambda.
 const initialiseHandler = async () => {
   const elasticClient = await getElasticClient({
-    pipelineDate: "2023-03-24",
+    pipelineDate: config.pipelineDate,
     serviceName: "pipeline",
   });
   const prismicClient = createPrismicClient();


### PR DESCRIPTION
I moved some stuff around when I was thinking about what config to inject via the environment - this makes the helper functions fairly agnostic as to their use, and puts code/config specific to our use case at the top level.