### PR TITLE
Use the new Terraform module to create ACM certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 # JetBrains IDEs
 .idea
+
+# Terraform
+*.plan

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -45,6 +45,13 @@ provider "registry.terraform.io/elastic/elasticstack" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.3.0"
+  hashes = [
+    "h1:pTPG9Kf1Qg2aPsZLXDa6OvLqsEXaMrKnp0Z4Q/TIBPA=",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.58.0"
   constraints = ">= 4.58.0"

--- a/infrastructure/api_stack/api_gateway.tf
+++ b/infrastructure/api_stack/api_gateway.tf
@@ -7,8 +7,8 @@ resource "aws_api_gateway_rest_api" "content" {
 }
 
 resource "aws_api_gateway_domain_name" "content_api" {
-  domain_name              = aws_acm_certificate.content_api.domain_name
-  regional_certificate_arn = aws_acm_certificate_validation.content.certificate_arn
+  domain_name              = local.cert_domain_name
+  regional_certificate_arn = module.cert.arn
   security_policy          = "TLS_1_2"
 
   endpoint_configuration {

--- a/infrastructure/api_stack/certificate.tf
+++ b/infrastructure/api_stack/certificate.tf
@@ -1,39 +1,23 @@
-resource "aws_acm_certificate" "content_api" {
+locals {
   // This is not the same as the external hostname!
   // It should correspond to the origin domains in the CloudFront distribution:
   // https://github.com/wellcomecollection/platform-infrastructure/blob/main/cloudfront/api.wellcomecollection.org/main.tf
-  domain_name       = "content.api-${var.environment}.wellcomecollection.org"
-  validation_method = "DNS"
+  cert_domain_name = "content.api-${var.environment}.wellcomecollection.org"
+}
 
-  lifecycle {
-    create_before_destroy = true
+module "cert" {
+  source = "github.com/wellcomecollection/terraform-aws-acm-certificate?ref=v1.0.0"
+
+  domain_name = local.cert_domain_name
+
+  zone_id = data.aws_route53_zone.dotorg.id
+
+  providers = {
+    aws.dns = aws.dns
   }
 }
 
 data "aws_route53_zone" "dotorg" {
   provider = aws.dns
   name     = "wellcomecollection.org."
-}
-
-resource "aws_route53_record" "content_certificate_validation" {
-  provider = aws.dns
-  for_each = {
-    for dvo in aws_acm_certificate.content_api.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  allow_overwrite = true
-  name            = each.value.name
-  records         = [each.value.record]
-  ttl             = 60
-  type            = each.value.type
-  zone_id         = data.aws_route53_zone.dotorg.zone_id
-}
-
-resource "aws_acm_certificate_validation" "content" {
-  certificate_arn         = aws_acm_certificate.content_api.arn
-  validation_record_fqdns = [for record in aws_route53_record.content_certificate_validation : record.fqdn]
 }


### PR DESCRIPTION
For https://github.com/wellcomecollection/platform/issues/5677

I haven't done any state wrangling for this change yet – when I plan locally, Terraform wants to tear down a bunch of Lambda resources that are presumably in somebody's local branch somewhere.