### PR TITLE
Set a default format of Article

### DIFF
--- a/common/data/formats.ts
+++ b/common/data/formats.ts
@@ -1,0 +1,32 @@
+// These are the types we make addressable from Prismic
+export const contentTypes = [
+  "articles",
+  "books",
+  "event-series",
+  "events",
+  "exhibitions",
+  "guides",
+  "pages",
+  "projects",
+  "seasons",
+  "series",
+  "webcomics",
+  "guide-formats",
+  "exhibition-guides",
+  "stories-landing",
+] as const;
+
+export const articleFormatIds = {
+  InPictures: "W5uKaCQAACkA3C0T",
+  Article: "W7TfJRAAAJ1D0eLK",
+  Comic: "W7d_ghAAALWY3Ujc",
+  Podcast: "XwRZ6hQAAG4K-bbt",
+  BookExtract: "W8CbPhEAAB8Nq4aG",
+  LongRead: "YxcjgREAACAAkjBg",
+};
+
+export const defaultArticleFormat = {
+  type: "ArticleFormat",
+  id: "W7TfJRAAAJ1D0eLK",
+  label: "Article",
+};

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -16,6 +16,7 @@ import {
   EmptyImageFieldImage,
   PrismicDocument,
 } from "@prismicio/types";
+import { defaultArticleFormat } from "@weco/content-common/data/formats";
 
 const getContributors = (
   document: PrismicDocument<WithContributors>
@@ -101,11 +102,7 @@ export const transformArticle = (
 
   const format = isFilledLinkToDocumentWithData(data.format)
     ? transformLabelType(data.format)
-    : ({
-        type: "ArticleFormat",
-        id: "W7TfJRAAAJ1D0eLK",
-        label: "Article",
-      } as ArticleFormat);
+    : (defaultArticleFormat as ArticleFormat);
 
   // When we imported data into Prismic from the Wordpress blog some content
   // needed to have its original publication date displayed. It is purely a display

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -101,7 +101,11 @@ export const transformArticle = (
 
   const format = isFilledLinkToDocumentWithData(data.format)
     ? transformLabelType(data.format)
-    : undefined;
+    : ({
+        type: "ArticleFormat",
+        id: "W7TfJRAAAJ1D0eLK",
+        label: "Article",
+      } as ArticleFormat);
 
   // When we imported data into Prismic from the Wordpress blog some content
   // needed to have its original publication date displayed. It is purely a display

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -82,7 +82,7 @@ function transformLabelType(
   return {
     type: "ArticleFormat",
     id: format.id as ArticleFormatId,
-    label: asText(format.data.title),
+    label: asText(format.data.title) as string,
   };
 }
 

--- a/pipeline/src/types/prismic/formats.ts
+++ b/pipeline/src/types/prismic/formats.ts
@@ -1,36 +1,13 @@
 import { PrismicDocument, RichTextField } from "@prismicio/types";
-
-// These are the types we make addressable from Prismic
-const contentTypes = [
-  "articles",
-  "books",
-  "event-series",
-  "events",
-  "exhibitions",
-  "guides",
-  "pages",
-  "projects",
-  "seasons",
-  "series",
-  "webcomics",
-  "guide-formats",
-  "exhibition-guides",
-  "stories-landing",
-] as const;
+import {
+  articleFormatIds,
+  contentTypes,
+} from "@weco/content-common/data/formats";
 
 export type ContentType = (typeof contentTypes)[number];
 
-const ArticleFormatIds = {
-  InPictures: "W5uKaCQAACkA3C0T",
-  Article: "W7TfJRAAAJ1D0eLK",
-  Comic: "W7d_ghAAALWY3Ujc",
-  Podcast: "XwRZ6hQAAG4K-bbt",
-  BookExtract: "W8CbPhEAAB8Nq4aG",
-  LongRead: "YxcjgREAACAAkjBg",
-};
-
 export type ArticleFormatId =
-  (typeof ArticleFormatIds)[keyof typeof ArticleFormatIds];
+  (typeof articleFormatIds)[keyof typeof articleFormatIds];
 
 export type PrismicArticleFormat = PrismicDocument<
   {

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -37,5 +37,5 @@ export type Contributor = {
 export type ArticleFormat = {
   type: "ArticleFormat";
   id: ArticleFormatId;
-  label?: string;
+  label: string;
 };

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -7,7 +7,7 @@ export type Article = {
   title: string;
   publicationDate: string;
   contributors: Contributor[];
-  format?: ArticleFormat;
+  format: ArticleFormat;
   image?: Image;
   caption?: string;
 };


### PR DESCRIPTION
Some articles don't have a defined format, in which case we always want it to be Article.

Twinned with [wc.org changes](https://github.com/wellcomecollection/wellcomecollection.org/pull/9577)

Relates to #9575