### PR TITLE
use wildcards to make sure we're querying all of the useful subfields

### DIFF
--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -1,13 +1,14 @@
-import { RequestHandler } from "express";
-import asyncHandler from "express-async-handler";
 import { Clients, Displayable, ResultList } from "../types";
-import { Config } from "../../config";
-import { HttpError } from "./error";
 import {
-  paginationElasticBody,
   PaginationQueryParameters,
+  paginationElasticBody,
   paginationResponseGetter,
 } from "./pagination";
+
+import { Config } from "../../config";
+import { HttpError } from "./error";
+import { RequestHandler } from "express";
+import asyncHandler from "express-async-handler";
 
 type QueryParams = {
   query?: string;
@@ -44,14 +45,12 @@ const articlesController = (
                   multi_match: {
                     query: queryString,
                     fields: [
-                      "query.title.shingles^100",
-                      "query.title.keyword^100",
-                      "query.contributors^10",
+                      "query.title.*^100",
+                      "query.contributors.*^10",
                       "query.contributors.keyword^100",
-                      "query.title.cased^10",
-                      "query.standfirst^10",
-                      "query.body",
-                      "query.caption",
+                      "query.standfirst.*^10",
+                      "query.body.*",
+                      "query.caption.*",
                     ],
                     operator: "or",
                     type: "cross_fields",


### PR DESCRIPTION
[Feedback on the new content api](https://wellcome.slack.com/archives/C3N7J05TK/p1681217319076659?thread_ts=1681216275.074579&cid=C3N7J05TK) indicates that our current query isn't looking at the fully analysed text for some fields. 

For example, searching for **parkinsons** doesn't return results where **parkinson's** (with an apostrophe) appears in the article's `body`.   
While the basic, top-level `text` field's analyser won't be able to handle nuances like apostrophes, the `body` field has subfields which use the `english_shingle_analyzer` and `english_cased_analyzer` analysers, which _should_ be able to cope. The problem is that we're not currently pointing the query at those subfields.

This PR updates the query with wildcards at the end of the top-level field names, ensuring that we search in all of their subfields. 

With the new query, results should include the extra articles we want to see:

<img width="871" alt="Screenshot 2023-04-11 at 16 14 19" src="https://user-images.githubusercontent.com/11006680/231208605-94101b71-c368-4fea-adac-b1f9fc4449c9.png">
