### PR TITLE
index the complete article body

### DIFF
--- a/pipeline/src/indices/articles.ts
+++ b/pipeline/src/indices/articles.ts
@@ -115,13 +115,9 @@ export const settings = {
         type: "stemmer",
         language: "possessive_english",
       },
-      asciifolding_token_filter: {
-        type: "asciifolding",
-        preserve_original: true,
-      },
       punctuation_token_filter: {
         type: "pattern_replace",
-        pattern: "[^\\w\\s]",
+        pattern: "[^0-9\\p{L}\\s]",
         replacement: "",
       },
     },
@@ -129,18 +125,18 @@ export const settings = {
       english_shingle_analyzer: {
         filter: [
           "lowercase",
-          "asciifolding_token_filter",
+          "asciifolding",
           "english_stemmer",
           "english_possessive_stemmer",
-          "shingle_filter",
           "punctuation_token_filter",
+          "shingle_filter",
         ],
         type: "custom",
         tokenizer: "standard",
       },
       english_cased_analyzer: {
         filter: [
-          "asciifolding_token_filter",
+          "asciifolding",
           "english_stemmer",
           "english_possessive_stemmer",
           "punctuation_token_filter",

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -116,8 +116,14 @@ export const transformArticle = (
     .filter(isNotUndefined);
 
   const queryBody = data.body
-    ?.map((b) => b.primary.text.map((t) => t.text).find((t) => t))
-    .join(" ");
+    ?.map((slice) => {
+      if (["text", "quoteV2", "standfirst"].includes(slice.slice_type)) {
+        return slice.primary.text.map((text) => text.text);
+      } else {
+        return [];
+      }
+    })
+    .flat();
 
   const queryStandfirst = data.body?.find((b) => b.slice_type === "standfirst")
     ?.primary.text[0].text;

--- a/pipeline/src/types/index.ts
+++ b/pipeline/src/types/index.ts
@@ -46,7 +46,7 @@ export type ElasticsearchArticle = {
     publicationDate: Date;
     contributors: string[];
     caption?: string;
-    body?: string;
+    body?: string[] | string;
     standfirst?: string;
   };
 };


### PR DESCRIPTION
At the moment we're not indexing body text beyond the first paragraph of an article's body, so a lot of documents with relevant keywords in their body are being missed! For example, [_Are doctors medical detectives?_](https://wellcomecollection.org/articles/XKIXNRAAAJsnbmFE) is missing from a search for **parkinsons** because the word only appears after the second paragraph.

This PR indexes _all_ of the body's `text` fields, and adds in `quoteV2`s and `standfirst`s for good measure.

I've also shuffled a couple of the filters in the mapping - these should only have a minor positive effect on scoring.