### PR TITLE
Use PrivateLink again

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -8,9 +8,12 @@ import { getElasticClient } from "@weco/content-common/services/elasticsearch";
 
 const config = getConfig();
 
+const isRunningInECS = "ECS_CONTAINER_METADATA_URI_V4" in process.env;
+
 getElasticClient({
   serviceName: "api",
   pipelineDate: config.pipelineDate,
+  hostEndpointAccess: isRunningInECS ? "private" : "public",
 }).then(async (elasticClient) => {
   const app = createApp({ elastic: elasticClient }, config);
   const port = process.env.PORT ?? 3000;

--- a/common/services/elasticsearch.ts
+++ b/common/services/elasticsearch.ts
@@ -14,9 +14,7 @@ const getElasticClientConfig = async ({
   hostEndpointAccess = "public",
 }: ClientParameters): Promise<ClientOptions> => {
   const secretPrefix = `elasticsearch/content-${pipelineDate}`;
-  if (hostEndpointAccess === "private") {
-    log.info("Creating ES client for PrivateLink endpoint");
-  }
+  log.info(`Creating ES client for the ${hostEndpointAccess} endpoint`);
   const [host, password] = await Promise.all([
     getSecret(`${secretPrefix}/${hostEndpointAccess}_host`),
     getSecret(`${secretPrefix}/${serviceName}/password`),

--- a/common/services/elasticsearch.ts
+++ b/common/services/elasticsearch.ts
@@ -6,16 +6,15 @@ type ClientParameters = {
   serviceName: string;
 };
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const getElasticClientConfig = async ({
   pipelineDate,
   serviceName,
 }: ClientParameters): Promise<ClientOptions> => {
   const secretPrefix = `elasticsearch/content-${pipelineDate}`;
   const [host, password] = await Promise.all([
-    // We always use the public internet endpoint because since 8.6.0 the client's
-    // internal Transport class has failed when used with the PrivateLink endpoint.
-    // We should monitor releases to see if this gets resolved.
-    getSecret(`${secretPrefix}/public_host`),
+    getSecret(`${secretPrefix}/${isProduction ? "private" : "public"}_host`),
     getSecret(`${secretPrefix}/${serviceName}/password`),
   ]);
   return {

--- a/common/services/elasticsearch.ts
+++ b/common/services/elasticsearch.ts
@@ -4,17 +4,17 @@ import { getSecret } from "./aws";
 type ClientParameters = {
   pipelineDate: string;
   serviceName: string;
+  hostEndpointAccess: "private" | "public";
 };
-
-const isProduction = process.env.NODE_ENV === "production";
 
 const getElasticClientConfig = async ({
   pipelineDate,
   serviceName,
+  hostEndpointAccess = "public",
 }: ClientParameters): Promise<ClientOptions> => {
   const secretPrefix = `elasticsearch/content-${pipelineDate}`;
   const [host, password] = await Promise.all([
-    getSecret(`${secretPrefix}/${isProduction ? "private" : "public"}_host`),
+    getSecret(`${secretPrefix}/${hostEndpointAccess}_host`),
     getSecret(`${secretPrefix}/${serviceName}/password`),
   ]);
   return {

--- a/common/services/elasticsearch.ts
+++ b/common/services/elasticsearch.ts
@@ -1,5 +1,6 @@
 import { Client, ClientOptions } from "@elastic/elasticsearch";
 import { getSecret } from "./aws";
+import log from "./logging";
 
 type ClientParameters = {
   pipelineDate: string;
@@ -13,6 +14,9 @@ const getElasticClientConfig = async ({
   hostEndpointAccess = "public",
 }: ClientParameters): Promise<ClientOptions> => {
   const secretPrefix = `elasticsearch/content-${pipelineDate}`;
+  if (hostEndpointAccess === "private") {
+    log.info("Creating ES client for PrivateLink endpoint");
+  }
   const [host, password] = await Promise.all([
     getSecret(`${secretPrefix}/${hostEndpointAccess}_host`),
     getSecret(`${secretPrefix}/${serviceName}/password`),

--- a/infrastructure/locals.tf
+++ b/infrastructure/locals.tf
@@ -6,4 +6,12 @@ locals {
   private_subnets          = local.catalogue_networking["catalogue_vpc_private_subnets"]
   elastic_cloud_vpce_sg_id = local.shared_infra["ec_catalogue_privatelink_sg_id"]
   logging_cluster_id       = local.shared_infra["logging_cluster_id"]
+
+  ec_network_config = {
+    ec_privatelink_security_group_id = local.elastic_cloud_vpce_sg_id
+    ec_traffic_filters = [
+      local.shared_infra["ec_catalogue_privatelink_traffic_filter_id"],
+      local.shared_infra["ec_public_internet_traffic_filter_id"]
+    ]
+  }
 }

--- a/infrastructure/pipeline.tf
+++ b/infrastructure/pipeline.tf
@@ -4,4 +4,5 @@ module "pipeline" {
   pipeline_date = "2023-03-24"
 
   logging_cluster_id = local.logging_cluster_id
+  network_config     = local.ec_network_config
 }

--- a/infrastructure/pipeline_stack/elastic_cluster.tf
+++ b/infrastructure/pipeline_stack/elastic_cluster.tf
@@ -33,6 +33,13 @@ resource "ec_deployment" "content_cluster" {
   }
 }
 
+resource "ec_deployment_traffic_filter_association" "content_cluster" {
+  for_each = var.network_config.ec_traffic_filters
+
+  deployment_id     = ec_deployment.content_cluster.id
+  traffic_filter_id = each.value
+}
+
 data "ec_stack" "latest_patch" {
   version_regex = "8.6.?"
   region        = local.elastic_cloud_region

--- a/infrastructure/pipeline_stack/variables.tf
+++ b/infrastructure/pipeline_stack/variables.tf
@@ -5,3 +5,10 @@ variable "logging_cluster_id" {
 variable "pipeline_date" {
   type = string
 }
+
+variable "network_config" {
+  type = object({
+    ec_privatelink_security_group_id = string
+    ec_traffic_filters               = set(string)
+  })
+}

--- a/pipeline/src/lambda.ts
+++ b/pipeline/src/lambda.ts
@@ -16,6 +16,7 @@ const initialiseHandler = async () => {
   const elasticClient = await getElasticClient({
     pipelineDate: config.pipelineDate,
     serviceName: "pipeline",
+    hostEndpointAccess: "private",
   });
   const prismicClient = createPrismicClient();
   return createHandler({ elastic: elasticClient, prismic: prismicClient });

--- a/pipeline/src/local.ts
+++ b/pipeline/src/local.ts
@@ -8,6 +8,7 @@ const prismicClient = createPrismicClient();
 getElasticClient({
   pipelineDate: "2023-03-24",
   serviceName: "pipeline",
+  hostEndpointAccess: "public",
 }).then((elasticClient) => {
   const handler = createHandler({
     prismic: prismicClient,


### PR DESCRIPTION
I was wrong about this being a bug in the ES client - the issue was that (a) I'd forgotten to configure the PrivateLink traffic filters for the cluster, and (b) the way we chose which endpoint to use was indirect/unclear and think had changed inadvertently, obscuring the actual issue and leading me on a wild goose chase.