### PR TITLE
Add aggregations with correct faceting behaviour

### DIFF
--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -78,6 +78,7 @@ const articlesController = (
       articlesFilter
     );
 
+    // See comments in `queries/faceting.ts` for some explanation of what's going on here
     const facetedAggregations = ifDefined(initialAggregations, (aggs) =>
       rewriteAggregationsForFacets(aggs, initialFilters)
     );

--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -77,10 +77,17 @@ const articlesController = (
       params,
       articlesFilter
     );
+
+    const facetedAggregations = ifDefined(initialAggregations, (aggs) =>
+      rewriteAggregationsForFacets(aggs, initialFilters)
+    );
     const { postFilters, queryFilters } = partitionFiltersForFacets(
       initialAggregations ?? {},
       initialFilters
     );
+
+    // The date filter is a special case because 2 parameters filter 1 field,
+    // and it doesn't (currently) have a corresponding aggregation.
     const dateFilter =
       params["publicationDate.from"] || params["publicationDate.to"]
         ? articlesFilter.publicationDate(
@@ -98,9 +105,7 @@ const articlesController = (
       >({
         index,
         _source: ["display"],
-        aggregations: ifDefined(initialAggregations, (aggs) =>
-          rewriteAggregationsForFacets(aggs, initialFilters)
-        ),
+        aggregations: facetedAggregations,
         query: {
           bool: {
             must: ifDefined(queryString, articlesQuery),

--- a/api/src/controllers/validation.ts
+++ b/api/src/controllers/validation.ts
@@ -40,7 +40,7 @@ export const queryValidator = <Name, AllowedValue>({
         label: "Bad Request",
         description: `${name}: ${readableList(
           invalidValues
-        )} ${invalidMessage}. Please choose one of: ${readableList(
+        )} ${invalidMessage}. Please choose one of ${readableList(
           allowed,
           "or"
         )}`,
@@ -65,19 +65,28 @@ export const validateDate = (input: string): Date => {
     throw new HttpError({
       status: 400,
       label: "Bad Request",
-      description: `'${input}' is not a valid date. Please specify a date or datetime in ISO 8601 format.`,
+      description: `${quoted(
+        input
+      )} is not a valid date. Please specify a date or datetime in ISO 8601 format.`,
     });
   }
   return date;
 };
 
+const quoted = (str: string) => `'${str}'`;
+
+// For listing items (no Oxford comma)
 const readableList = (
   arr: readonly string[],
   conjunction: "and" | "or" = "and"
-): string =>
-  arr
-    .slice(0, -1)
-    .map((v) => `'${v}'`)
-    .join(", ") +
-  ` ${conjunction} ` +
-  arr[arr.length - 1];
+): string => {
+  if (arr.length === 0) {
+    return "";
+  }
+  const quotes = arr.map(quoted);
+  return arr.length > 1
+    ? `${quotes.slice(0, -1).join(", ")} ${conjunction} ${
+        quotes[quotes.length - 1]
+      }`
+    : quotes[0];
+};

--- a/api/src/controllers/validation.ts
+++ b/api/src/controllers/validation.ts
@@ -1,11 +1,6 @@
 import { HttpError } from "./error";
 import { isInSet, not } from "../helpers";
-
-type StringLiteral<T> = T extends string
-  ? string extends T
-    ? never
-    : T
-  : never;
+import { StringLiteral } from "../types";
 
 type NonEmptyArray<T> = [T, ...T[]];
 

--- a/api/src/helpers/elastic.ts
+++ b/api/src/helpers/elastic.ts
@@ -1,9 +1,20 @@
 import {
   AggregationsAggregate,
-  AggregationsStringTermsAggregate,
+  AggregationsTermsAggregateBase,
 } from "@elastic/elasticsearch/lib/api/types";
+
+// The built-in aggregation types are a bit inflexible, given how flexible the aggregations API is.
+// This is what the buckets returning from ES look like when we make an aggregation request
+// of the form in `queries/faceting.ts:rewriteAggregationsForFacets`
+type TermsBucket = {
+  doc_count: number;
+  key: string;
+  filtered?: {
+    doc_count: number;
+  };
+};
 
 export const isTermsAggregation = (
   agg: AggregationsAggregate
-): agg is AggregationsStringTermsAggregate =>
+): agg is AggregationsTermsAggregateBase<TermsBucket> =>
   "buckets" in agg && "doc_count" in agg.buckets[0] && "key" in agg.buckets[0];

--- a/api/src/helpers/elastic.ts
+++ b/api/src/helpers/elastic.ts
@@ -1,6 +1,6 @@
 import {
   AggregationsAggregate,
-  AggregationsTermsAggregateBase,
+  AggregationsMultiBucketAggregateBase,
 } from "@elastic/elasticsearch/lib/api/types";
 
 // The built-in aggregation types are a bit inflexible, given how flexible the aggregations API is.
@@ -14,7 +14,7 @@ type TermsBucket = {
   };
 };
 
-export const isTermsAggregation = (
+export const isMultiBucketAggregation = (
   agg: AggregationsAggregate
-): agg is AggregationsTermsAggregateBase<TermsBucket> =>
+): agg is AggregationsMultiBucketAggregateBase<TermsBucket> =>
   "buckets" in agg && "doc_count" in agg.buckets[0] && "key" in agg.buckets[0];

--- a/api/src/helpers/elastic.ts
+++ b/api/src/helpers/elastic.ts
@@ -1,0 +1,9 @@
+import {
+  AggregationsAggregate,
+  AggregationsStringTermsAggregate,
+} from "@elastic/elasticsearch/lib/api/types";
+
+export const isTermsAggregation = (
+  agg: AggregationsAggregate
+): agg is AggregationsStringTermsAggregate =>
+  "buckets" in agg && "doc_count" in agg.buckets[0] && "key" in agg.buckets[0];

--- a/api/src/helpers/index.ts
+++ b/api/src/helpers/index.ts
@@ -1,7 +1,8 @@
-export const isInArray = <T, A extends T>(
-  item: T,
-  array: ReadonlyArray<A>
-): item is A => array.includes(item as A);
+// The built-in types for `set.has` don't include a type guard
+export const isInSet =
+  <T, S extends T>(set: ReadonlySet<S>) =>
+  (item: T): item is S =>
+    set.has(item as S);
 
 export const ifDefined = <T, R>(
   maybeParam: T | undefined,
@@ -10,3 +11,16 @@ export const ifDefined = <T, R>(
 
 export const isNotUndefined = <T>(val: T | undefined): val is T =>
   val !== undefined;
+
+export const pick = <T extends {}, K extends keyof T>(
+  obj: T,
+  keys: K[]
+): Pick<T, K> =>
+  Object.fromEntries(
+    keys.filter((key) => key in obj).map((key) => [key, obj[key]])
+  ) as Pick<T, K>;
+
+export const not =
+  <T extends any[]>(f: (...params: T) => boolean) =>
+  (...params: T) =>
+    !f(...params);

--- a/api/src/helpers/requests.ts
+++ b/api/src/helpers/requests.ts
@@ -1,0 +1,24 @@
+import { StringLiteral } from "../types";
+import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
+import { ifDefined } from "./index";
+
+export const pickFiltersFromQuery = <
+  Name extends string,
+  Query extends { [key in Name]?: string },
+  Filters extends {
+    [key in Name]: (params: string[]) => QueryDslQueryContainer;
+  }
+>(
+  filterNames: ReadonlyArray<StringLiteral<Name>>,
+  query: Query,
+  filters: Filters
+): Record<string, QueryDslQueryContainer> =>
+  Object.fromEntries(
+    filterNames.flatMap((filterName) => {
+      const maybeFilter = ifDefined(
+        query[filterName]?.split(","),
+        filters[filterName]
+      );
+      return maybeFilter ? [[filterName, maybeFilter]] : [];
+    })
+  );

--- a/api/src/helpers/requests.ts
+++ b/api/src/helpers/requests.ts
@@ -12,7 +12,7 @@ export const pickFiltersFromQuery = <
   filterNames: ReadonlyArray<StringLiteral<Name>>,
   query: Query,
   filters: Filters
-): Record<string, QueryDslQueryContainer> =>
+): Record<Name, QueryDslQueryContainer> =>
   Object.fromEntries(
     filterNames.flatMap((filterName) => {
       const maybeFilter = ifDefined(
@@ -21,4 +21,4 @@ export const pickFiltersFromQuery = <
       );
       return maybeFilter ? [[filterName, maybeFilter]] : [];
     })
-  );
+  ) as Record<Name, QueryDslQueryContainer>;

--- a/api/src/helpers/requests.ts
+++ b/api/src/helpers/requests.ts
@@ -2,6 +2,9 @@ import { StringLiteral } from "../types";
 import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
 import { ifDefined } from "./index";
 
+// Given an object of query parameters, and one with the same keys
+// of functions that create filter objects, apply all those functions
+// to the corresponding parameters and return an object of the filters
 export const pickFiltersFromQuery = <
   Name extends string,
   Query extends { [key in Name]?: string },

--- a/api/src/helpers/responses.ts
+++ b/api/src/helpers/responses.ts
@@ -27,7 +27,10 @@ const mapAggregations = (
                   // parse it something has gone wrong in the pipeline and we
                   // should know about it
                   data: JSON.parse(bucket.key),
-                  count: bucket.doc_count,
+                  // If there is a filter subaggregation (named `filtered`), we should
+                  // use that: it will exist if other filters and aggregations are
+                  // applied in addition to the aggregation/filter corresponding to this bucket.
+                  count: bucket.filtered?.doc_count ?? bucket.doc_count,
                   type: "AggregationBucket",
                 })),
                 type: "Aggregation",

--- a/api/src/helpers/responses.ts
+++ b/api/src/helpers/responses.ts
@@ -1,0 +1,78 @@
+import { Request } from "express";
+import {
+  AggregationsAggregate,
+  SearchResponse,
+} from "@elastic/elasticsearch/lib/api/types";
+import { Displayable } from "../types";
+import { Aggregation, Aggregations, ResultList } from "../types/responses";
+import { Config } from "../../config";
+import { paginationResponseGetter } from "../controllers/pagination";
+import { isTermsAggregation } from "./elastic";
+
+const mapAggregations = (
+  elasticAggs: AggregationsAggregate
+): Aggregations | undefined =>
+  Object.fromEntries(
+    Object.entries(elasticAggs).flatMap(([name, aggregation]) =>
+      isTermsAggregation(aggregation) &&
+      // The built-in types in the ES client claim that buckets can be a Record<string, TBucket>.
+      // This seems dubious to me, but I'm jumping through the hoop nonetheless.
+      Array.isArray(aggregation.buckets)
+        ? [
+            [
+              name,
+              {
+                buckets: aggregation.buckets.map((bucket) => ({
+                  // This should always be a JSONified string, so if we can't
+                  // parse it something has gone wrong in the pipeline and we
+                  // should know about it
+                  data: JSON.parse(bucket.key),
+                  count: bucket.doc_count,
+                  type: "AggregationBucket",
+                })),
+                type: "Aggregation",
+              },
+            ],
+          ]
+        : []
+    )
+  );
+
+export const resultListResponse = (config: Config) => {
+  const getPaginationResponse = paginationResponseGetter(config.publicRootUrl);
+
+  return <R extends Request<any, any, any, any>>(
+    req: R,
+    searchResponse: SearchResponse<Displayable>
+  ): ResultList => {
+    const results = searchResponse.hits.hits.flatMap((hit) =>
+      hit._source ? [hit._source.display] : []
+    );
+
+    const aggregations: Aggregations | undefined = searchResponse.aggregations
+      ? mapAggregations(searchResponse.aggregations)
+      : undefined;
+
+    const requestUrl = new URL(
+      req.url,
+      `${req.protocol}://${req.headers.host}`
+    );
+
+    const totalResults =
+      typeof searchResponse.hits.total === "number"
+        ? searchResponse.hits.total
+        : searchResponse.hits.total?.value ?? 0;
+
+    const paginationResponse = getPaginationResponse({
+      requestUrl,
+      totalResults,
+    });
+
+    return {
+      type: "ResultList",
+      results,
+      aggregations,
+      ...paginationResponse,
+    };
+  };
+};

--- a/api/src/helpers/responses.ts
+++ b/api/src/helpers/responses.ts
@@ -7,14 +7,14 @@ import { Displayable } from "../types";
 import { Aggregation, Aggregations, ResultList } from "../types/responses";
 import { Config } from "../../config";
 import { paginationResponseGetter } from "../controllers/pagination";
-import { isTermsAggregation } from "./elastic";
+import { isMultiBucketAggregation } from "./elastic";
 
-const mapAggregations = (
+export const mapAggregations = (
   elasticAggs: AggregationsAggregate
-): Aggregations | undefined =>
+): Aggregations =>
   Object.fromEntries(
     Object.entries(elasticAggs).flatMap(([name, aggregation]) =>
-      isTermsAggregation(aggregation) &&
+      isMultiBucketAggregation(aggregation) &&
       // The built-in types in the ES client claim that buckets can be a Record<string, TBucket>.
       // This seems dubious to me, but I'm jumping through the hoop nonetheless.
       Array.isArray(aggregation.buckets)

--- a/api/src/queries/articles.ts
+++ b/api/src/queries/articles.ts
@@ -1,4 +1,5 @@
-import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/typesWithBodyKey";
+import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
+
 export const articlesQuery = (queryString: string): QueryDslQueryContainer => ({
   multi_match: {
     query: queryString,
@@ -22,7 +23,9 @@ export const articlesQuery = (queryString: string): QueryDslQueryContainer => ({
 });
 
 export const articlesFilter = {
-  contributors: (contributors: string[]): QueryDslQueryContainer => ({
+  "contributors.contributor": (
+    contributors: string[]
+  ): QueryDslQueryContainer => ({
     terms: {
       "filter.contributorIds": contributors,
     },
@@ -41,3 +44,23 @@ export const articlesFilter = {
     },
   }),
 };
+
+export const articlesAggregations = {
+  "contributors.contributor": {
+    terms: {
+      // At time of writing (2023-05-19) there are 560 contributors, too many to consider
+      // returning all of them in the aggregation
+      size: 20,
+      field: "aggregatableValues.contributors",
+    },
+  },
+  format: {
+    terms: {
+      // At time of writing (2023-05-19) we have 10 article formats. This list is likely
+      // to remain fairly stable, but I have chosen to use 20 as the size here so we have
+      // some buffer if we add more formats
+      size: 20,
+      field: "aggregatableValues.format",
+    },
+  },
+} as const;

--- a/api/src/queries/faceting.ts
+++ b/api/src/queries/faceting.ts
@@ -1,0 +1,69 @@
+import {
+  AggregationsAggregationContainer,
+  QueryDslQueryContainer,
+} from "@elastic/elasticsearch/lib/api/types";
+
+const allOtherFilters = (
+  filters: Record<string, QueryDslQueryContainer>,
+  nameToExclude: string
+): QueryDslQueryContainer => ({
+  bool: {
+    filter: Object.entries(filters)
+      .filter(([filterName]) => filterName !== nameToExclude)
+      .map(([_, filter]) => filter),
+  },
+});
+
+const filtered = (
+  aggregation: AggregationsAggregationContainer
+): AggregationsAggregationContainer =>
+  "terms" in aggregation
+    ? {
+        ...aggregation,
+        terms: {
+          ...aggregation.terms,
+          min_doc_count: 0,
+          order: {
+            filtered: "desc",
+          },
+        },
+      }
+    : aggregation;
+
+export const rewriteAggregationsForFacets = (
+  aggregations: Record<string, AggregationsAggregationContainer>,
+  filters: Record<string, QueryDslQueryContainer>
+): Record<string, AggregationsAggregationContainer> =>
+  Object.fromEntries(
+    Object.entries(aggregations).map(([name, agg]) => [
+      name,
+      name in filters
+        ? {
+            ...filtered(agg),
+            aggs: {
+              filtered: {
+                filter: allOtherFilters(filters, name),
+              },
+            },
+          }
+        : agg,
+    ])
+  );
+
+export const partitionFiltersForFacets = (
+  aggregations: Record<string, AggregationsAggregationContainer>,
+  filters: Record<string, QueryDslQueryContainer>
+) => {
+  const postFilters: QueryDslQueryContainer[] = [];
+  const queryFilters: QueryDslQueryContainer[] = [];
+
+  for (const [filterName, filter] of Object.entries(filters)) {
+    if (filterName in aggregations) {
+      postFilters.push(filter);
+    } else {
+      queryFilters.push(filter);
+    }
+  }
+
+  return { postFilters, queryFilters };
+};

--- a/api/src/queries/faceting.ts
+++ b/api/src/queries/faceting.ts
@@ -3,20 +3,36 @@ import {
   QueryDslQueryContainer,
 } from "@elastic/elasticsearch/lib/api/types";
 
-const allOtherFilters = (
-  filters: Record<string, QueryDslQueryContainer>,
-  nameToExclude: string
-): QueryDslQueryContainer => ({
-  bool: {
-    filter: Object.entries(filters)
-      .filter(([filterName]) => filterName !== nameToExclude)
-      .map(([_, filter]) => filter),
-  },
-});
+// This file contains functions to rewrite terms aggregations and filters
+// in order to fulfil the requirements of a faceting interface as documented
+// in the RFC, "API faceting principles & expectations":
+// https://github.com/wellcomecollection/docs/tree/main/rfcs/037-api-faceting-principles
+// Refer to the RFC for motivation regarding expected behaviour, and refer to
+// comments in this file for motivation regarding implementation.
 
+const excludeValue = <T>(
+  record: Record<string, T>,
+  keyToExclude: string
+): T[] =>
+  Object.entries(record)
+    .filter(([key]) => key !== keyToExclude)
+    .map(([_, value]) => value);
+
+// If we are adding a `filter` sub-aggregation to a `terms` aggregation, this means
+// that we have also applied the filter corresponding to the aggregated value, and
+// so we want to tweak the aggregation in a couple of ways:
+// 1. `min_doc_count: 0`: necessary to fulfil point (6) of the RFC,
+//    "When a filter and its paired aggregation are both applied, the bucket corresponding to the filtered value is always present"
+// 2. `order.filtered: "desc"`: we want buckets to be ordered by the filtered value
+//     because this will be the value returned to consumers of the API.
+//
+// see also:
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_minimum_document_count_4
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_ordering_by_a_sub_aggregation
 const filtered = (
   aggregation: AggregationsAggregationContainer
 ): AggregationsAggregationContainer =>
+  // See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
   "terms" in aggregation
     ? {
         ...aggregation,
@@ -37,12 +53,20 @@ export const rewriteAggregationsForFacets = (
   Object.fromEntries(
     Object.entries(aggregations).map(([name, agg]) => [
       name,
-      name in filters
+      name in filters // If we have applied the filter corresponding to this aggregation
         ? {
-            ...filtered(agg),
+            ...filtered(agg), // See above
             aggs: {
+              // The sub-aggregation has a fixed name, `filtered`, and applies all requested
+              // filters _except_ for the one it corresponds to. This is to fulfil point (5) of the RFC:
+              // "When a filter and its paired aggregation are both applied, that aggregation's buckets are not filtered"
               filtered: {
-                filter: allOtherFilters(filters, name),
+                // See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filter-aggregation.html
+                filter: {
+                  bool: {
+                    filter: excludeValue(filters, name),
+                  },
+                },
               },
             },
           }
@@ -50,6 +74,14 @@ export const rewriteAggregationsForFacets = (
     ])
   );
 
+// While we do want all requested filters to apply to our search results, we don't
+// necessarily want them to apply to all aggregations. ES provides `post_filter` for
+// this purpose, and recommends its use for building faceted search interfaces.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-search-results.html#post-filter
+//
+// This just separates the requested filters into those for which a corresponding aggregation
+// has been requested (to be used in `post_filter`) and those which have no corresponding aggregation
+// (to be used in the normal `query`).
 export const partitionFiltersForFacets = (
   aggregations: Record<string, AggregationsAggregationContainer>,
   filters: Record<string, QueryDslQueryContainer>

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -7,3 +7,9 @@ export type Displayable = {
 export type Clients = {
   elastic: ElasticClient;
 };
+
+export type StringLiteral<T> = T extends string
+  ? string extends T
+    ? never
+    : T
+  : never;

--- a/api/src/types/index.ts
+++ b/api/src/types/index.ts
@@ -1,15 +1,7 @@
 import { Client as ElasticClient } from "@elastic/elasticsearch";
 
-export type Displayable<T = any> = {
-  display: T;
-};
-
-export type ResultList<Result = any> = {
-  type: "ResultList";
-  results: Result[];
-  totalResults: number;
-  totalPages: number;
-  pageSize: number;
+export type Displayable = {
+  display: any;
 };
 
 export type Clients = {

--- a/api/src/types/responses.ts
+++ b/api/src/types/responses.ts
@@ -1,0 +1,18 @@
+export type Aggregations = Record<string, Aggregation>;
+export type Aggregation = {
+  buckets: Array<{
+    data: any;
+    count: number;
+    type: "AggregationBucket";
+  }>;
+  type: "Aggregation";
+};
+
+export type ResultList<Result = any> = {
+  type: "ResultList";
+  results: Result[];
+  aggregations?: Aggregations;
+  totalResults: number;
+  totalPages: number;
+  pageSize: number;
+};

--- a/api/test/__snapshots__/query.test.ts.snap
+++ b/api/test/__snapshots__/query.test.ts.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`articles query makes the expected query to ES for a given set of query parameters 1`] = `
+{
+  "_source": [
+    "display",
+  ],
+  "aggregations": {
+    "format": {
+      "aggs": {
+        "filtered": {
+          "filter": {
+            "bool": {
+              "filter": [
+                {
+                  "terms": {
+                    "filter.contributorIds": [
+                      "test-contributor",
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      "terms": {
+        "field": "aggregatableValues.format",
+        "min_doc_count": 0,
+        "order": {
+          "filtered": "desc",
+        },
+        "size": 20,
+      },
+    },
+  },
+  "from": 336,
+  "index": "test",
+  "post_filter": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "filter.formatId": [
+              "test-format",
+            ],
+          },
+        },
+      ],
+    },
+  },
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "filter.contributorIds": [
+              "test-contributor",
+            ],
+          },
+        },
+        {
+          "range": {
+            "filter.publicationDate": {
+              "gte": "2022-02-22T00:00:00.000Z",
+              "lte": "2023-03-23T00:00:00.000Z",
+            },
+          },
+        },
+      ],
+      "must": {
+        "multi_match": {
+          "fields": [
+            "id",
+            "query.title.*^100",
+            "query.contributors.*^10",
+            "query.contributors.keyword^100",
+            "query.standfirst.*^10",
+            "query.body.*",
+            "query.caption.*",
+            "query.series.id",
+            "query.series.title.*^80",
+            "query.series.contributors*^8",
+            "query.series.contributors.keyword^80",
+          ],
+          "minimum_should_match": "-25%",
+          "operator": "or",
+          "query": "henry wellcome",
+          "type": "cross_fields",
+        },
+      },
+    },
+  },
+  "size": 42,
+  "sort": [
+    {
+      "query.publicationDate": {
+        "order": "asc",
+      },
+    },
+    {
+      "query.publicationDate": {
+        "order": "desc",
+      },
+    },
+  ],
+}
+`;

--- a/api/test/__snapshots__/responses.test.ts.snap
+++ b/api/test/__snapshots__/responses.test.ts.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mapAggregations maps aggregations responses from ES to our expected response format 1`] = `
+{
+  "format": {
+    "buckets": [
+      {
+        "count": 595,
+        "data": {
+          "id": "W7TfJRAAAJ1D0eLK",
+          "label": "Article",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 271,
+        "data": {
+          "id": "W7d_ghAAALWY3Ujc",
+          "label": "Comic",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 137,
+        "data": {
+          "id": "W5uKaCQAACkA3C0T",
+          "label": "In pictures",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 38,
+        "data": {
+          "id": "W8CbPhEAAB8Nq4aG",
+          "label": "Book extract",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 19,
+        "data": {
+          "id": "XTYCkRAAACUANeph",
+          "label": "Photo story",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 16,
+        "data": {
+          "id": "XwRZ6hQAAG4K-bbt",
+          "label": "Podcast",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 10,
+        "data": {
+          "id": "W9BoHhIAANBp1EXg",
+          "label": "Interview",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 3,
+        "data": {
+          "id": "ZBH6PRQAAIrrFirA",
+          "label": "Short film",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 2,
+        "data": {
+          "id": "YxcjgREAACAAkjBg",
+          "label": "Long read",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+      {
+        "count": 1,
+        "data": {
+          "id": "YrwCTxEAACUALJQ0",
+          "label": "Prose poem",
+          "type": "ArticleFormat",
+        },
+        "type": "AggregationBucket",
+      },
+    ],
+    "type": "Aggregation",
+  },
+}
+`;

--- a/api/test/faceting.test.ts
+++ b/api/test/faceting.test.ts
@@ -1,0 +1,71 @@
+import { articlesAggregations, articlesFilter } from "../src/queries/articles";
+import {
+  partitionFiltersForFacets,
+  rewriteAggregationsForFacets,
+} from "../src/queries/faceting";
+import { SortOrder } from "@elastic/elasticsearch/lib/api/types";
+
+describe("rewriteAggregationsForFacets", () => {
+  it("rewrites aggregations correctly when their corresponding filters are present", () => {
+    const { format } = articlesAggregations;
+    const aggregations = { format };
+    const filters = {
+      format: articlesFilter.format(["test"]),
+      "contributors.contributor": articlesFilter["contributors.contributor"]([
+        "test",
+      ]),
+    };
+    const facetedAggregations = rewriteAggregationsForFacets(
+      aggregations,
+      filters
+    );
+
+    const rewrittenFormatAgg = facetedAggregations.format;
+    expect(rewrittenFormatAgg.terms?.min_doc_count).toBe(0);
+    expect(
+      (rewrittenFormatAgg.terms?.order as Record<string, SortOrder>).filtered
+    ).toBe("desc");
+    expect(rewrittenFormatAgg.aggs?.filtered.filter?.bool?.filter).toBeArray();
+    expect(
+      rewrittenFormatAgg.aggs?.filtered.filter?.bool?.filter
+    ).toIncludeAnyMembers([filters["contributors.contributor"]]);
+  });
+
+  it("does not modify aggregations which have no corresponding filter present", () => {
+    const { format } = articlesAggregations;
+    const aggregations = { format };
+    const filters = {
+      "contributors.contributor": articlesFilter["contributors.contributor"]([
+        "test",
+      ]),
+    };
+    const facetedAggregations = rewriteAggregationsForFacets(
+      aggregations,
+      filters
+    );
+
+    expect(facetedAggregations.format).toStrictEqual(format);
+  });
+});
+
+describe("partitionFiltersForFacets", () => {
+  it("separates filters correctly depending on whether a corresponding aggregation is present", () => {
+    const { format } = articlesAggregations;
+    const aggregations = { format };
+    const filters = {
+      format: articlesFilter.format(["test"]),
+      "contributors.contributor": articlesFilter["contributors.contributor"]([
+        "test",
+      ]),
+    };
+
+    const { postFilters, queryFilters } = partitionFiltersForFacets(
+      aggregations,
+      filters
+    );
+    expect(postFilters).toIncludeAllMembers([filters.format]);
+    expect(queryFilters).toIncludeAllMembers([
+      filters["contributors.contributor"],
+    ]);
+  });
+});

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -1,0 +1,71 @@
+import { Client as ElasticClient } from "@elastic/elasticsearch";
+import { SearchRequest } from "@elastic/elasticsearch/lib/api/types";
+import supertest from "supertest";
+import createApp from "../src/app";
+import { URL, URLSearchParams } from "url";
+
+describe("articles query", () => {
+  // The purpose of this test is as a smoke test for the question,
+  // "do we understand how we map a given query into an ES request?"
+  it("makes the expected query to ES for a given set of query parameters", async () => {
+    const aggregations = "format";
+    const format = "test-format";
+    const contributor = "test-contributor";
+    const pageSize = 42;
+    const page = 9;
+    const dateFrom = "2022-02-22";
+    const dateTo = "2023-03-23";
+    const sort = "publicationDate";
+    const sortOrder = "asc";
+    const query = "henry wellcome";
+
+    const params = new URLSearchParams({
+      aggregations,
+      format,
+      page,
+      pageSize,
+      sort,
+      sortOrder,
+      query,
+      "publicationDate.from": dateFrom,
+      "publicationDate.to": dateTo,
+      "contributors.contributor": contributor,
+    } as unknown as Record<string, string>);
+    const esRequest = await elasticsearchRequestForURL(
+      `/articles?${params.toString()}`
+    );
+
+    expect(esRequest.from).toBe((page - 1) * pageSize);
+    expect(esRequest.size).toBe(pageSize);
+    expect(esRequest.aggregations).toContainAllKeys([aggregations]);
+
+    expect(JSON.stringify(esRequest.query?.bool?.must)).toInclude(query);
+    expect(JSON.stringify(esRequest.query?.bool?.filter)).toInclude(
+      contributor
+    );
+    expect(JSON.stringify(esRequest.query?.bool?.filter)).toInclude(dateFrom);
+    expect(JSON.stringify(esRequest.query?.bool?.filter)).toInclude(dateTo);
+    expect(JSON.stringify(esRequest.post_filter?.bool?.filter)).toInclude(
+      format
+    );
+
+    expect(esRequest).toMatchSnapshot();
+  });
+});
+
+const elasticsearchRequestForURL = async (
+  url: string
+): Promise<SearchRequest> => {
+  const searchSpy = jest.fn();
+  const app = createApp(
+    { elastic: { search: searchSpy } as unknown as ElasticClient },
+    {
+      pipelineDate: "2222-22-22",
+      contentsIndex: "test",
+      publicRootUrl: new URL("http://test.test/test"),
+    }
+  );
+  const api = supertest.agent(app);
+  await api.get(url);
+  return searchSpy.mock.lastCall[0] as SearchRequest;
+};

--- a/api/test/responses.test.ts
+++ b/api/test/responses.test.ts
@@ -1,0 +1,84 @@
+import { mapAggregations } from "../src/helpers/responses";
+
+describe("mapAggregations", () => {
+  it("maps aggregations responses from ES to our expected response format", () => {
+    const elasticAggregations = {
+      format: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: '{"type":"ArticleFormat","id":"W7TfJRAAAJ1D0eLK","label":"Article"}',
+            doc_count: 595,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"W7d_ghAAALWY3Ujc","label":"Comic"}',
+            doc_count: 271,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"W5uKaCQAACkA3C0T","label":"In pictures"}',
+            doc_count: 137,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"W8CbPhEAAB8Nq4aG","label":"Book extract"}',
+            doc_count: 38,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"XTYCkRAAACUANeph","label":"Photo story"}',
+            doc_count: 19,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"XwRZ6hQAAG4K-bbt","label":"Podcast"}',
+            doc_count: 16,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"W9BoHhIAANBp1EXg","label":"Interview"}',
+            doc_count: 10,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"ZBH6PRQAAIrrFirA","label":"Short film"}',
+            doc_count: 3,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"YxcjgREAACAAkjBg","label":"Long read"}',
+            doc_count: 2,
+          },
+          {
+            key: '{"type":"ArticleFormat","id":"YrwCTxEAACUALJQ0","label":"Prose poem"}',
+            doc_count: 1,
+          },
+        ],
+      },
+    };
+    const mappedAggregations = mapAggregations(elasticAggregations);
+    expect(mappedAggregations.format.buckets).toHaveLength(
+      elasticAggregations.format.buckets.length
+    );
+    expect(mappedAggregations).toMatchSnapshot();
+  });
+
+  it("uses the count from a bucket sub-aggregation named 'filtered' if it is present", () => {
+    const elasticAggregationsWithSubAgg = {
+      format: {
+        doc_count_error_upper_bound: 0,
+        sum_other_doc_count: 0,
+        buckets: [
+          {
+            key: '{"type":"ArticleFormat","id":"W7d_ghAAALWY3Ujc","label":"Comic"}',
+            doc_count: 271,
+            filtered: { doc_count: 159 },
+          },
+        ],
+      },
+    };
+    const mappedAggregations = mapAggregations(elasticAggregationsWithSubAgg);
+    expect(mappedAggregations.format.buckets[0].count).toBe(
+      elasticAggregationsWithSubAgg.format.buckets[0].filtered.doc_count
+    );
+    // Putting this inverse test case here to catch if the test data changes to make doc_count and filtered.doc_count
+    // equal - this is a perfectly valid/likely scenario but this test needs them to be different!
+    expect(mappedAggregations.format.buckets[0].count).not.toBe(
+      elasticAggregationsWithSubAgg.format.buckets[0].doc_count
+    );
+  });
+});

--- a/api/test/validation.test.ts
+++ b/api/test/validation.test.ts
@@ -7,20 +7,20 @@ describe("query validator", () => {
     allowed: ["a", "b"],
   });
   it("extracts allowed values from query parameters", () => {
-    expect(testValidator({ test: "a" })).toBe("a");
-    expect(testValidator({ test: "b" })).toBe("b");
+    expect(testValidator({ test: "a" })).toStrictEqual(["a"]);
+    expect(testValidator({ test: "b" })).toStrictEqual(["b"]);
   });
 
   it("rejects values which are not in the allowlist", () => {
     expect(() =>
       testValidator({ test: "123" })
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Bad Request: test: '123' is not a valid value. Please choose one of: 'a', 'b'"`
+      `"Bad Request: test: '123' is not a valid value. Please choose one of 'a' or 'b'"`
     );
   });
 
   it("returns a given default value when the parameter is undefined", () => {
-    expect(testValidator({ test: undefined })).toBe("a");
+    expect(testValidator({ test: undefined })).toStrictEqual(["a"]);
   });
 });
 

--- a/api/test/validation.test.ts
+++ b/api/test/validation.test.ts
@@ -22,6 +22,24 @@ describe("query validator", () => {
   it("returns a given default value when the parameter is undefined", () => {
     expect(testValidator({ test: undefined })).toStrictEqual(["a"]);
   });
+
+  it("parses multiple values", () => {
+    expect(testValidator({ test: "a,b" })).toStrictEqual(["a", "b"]);
+  });
+
+  it("rejects multiple values if singleValue is specified", () => {
+    const testValidatorSingle = queryValidator({
+      name: "test",
+      defaultValue: "a",
+      allowed: ["a", "b"],
+      singleValue: true,
+    });
+    expect(() =>
+      testValidatorSingle({ test: "a,b" })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Bad Request: Only 1 value can be specified for test"`
+    );
+  });
 });
 
 describe("validateDate", () => {

--- a/pipeline/src/indices/articles.ts
+++ b/pipeline/src/indices/articles.ts
@@ -142,6 +142,16 @@ export const mapping = {
         },
       },
     },
+    aggregatableValues: {
+      properties: {
+        contributors: {
+          type: "keyword",
+        },
+        format: {
+          type: "keyword",
+        },
+      },
+    },
   },
 } as const;
 

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -152,6 +152,8 @@ export const transformArticle = (
       : []
   );
 
+  const flatContributors = contributors.flatMap((c) => c.contributor ?? []);
+
   return {
     id,
     display: {
@@ -175,9 +177,13 @@ export const transformArticle = (
       series: querySeries,
     },
     filter: {
-      contributorIds: contributors.flatMap((c) => c.contributor?.id ?? []),
+      contributorIds: flatContributors.map((c) => c.id),
       formatId: format.id,
       publicationDate: new Date(datePublished),
+    },
+    aggregatableValues: {
+      contributors: flatContributors.map((c) => JSON.stringify(c)),
+      format: JSON.stringify(format),
     },
   };
 };

--- a/pipeline/src/types/index.ts
+++ b/pipeline/src/types/index.ts
@@ -60,6 +60,10 @@ export type ElasticsearchArticle = {
     contributorIds: string[];
     formatId: string;
   };
+  aggregatableValues: {
+    contributors: string[];
+    format: string;
+  };
 };
 
 // Generic types

--- a/pipeline/test/transformers/__snapshots__/article.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/article.test.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`article transformer also works for webcomics (document: webcomics/XK9p2RIAAO1vQn__) 1`] = `
 {
+  "aggregatableValues": {
+    "contributors": [
+      "{"type":"Person","id":"WSQ9rygAAA9xtwfy","label":"Rob Bidder"}",
+    ],
+    "format": "{"type":"ArticleFormat","id":"W7d_ghAAALWY3Ujc","label":"Comic"}",
+  },
   "display": {
     "caption": "Groans are to our primitive nature what language is to civilization. Uggggghhhh.",
     "contributors": [
@@ -102,6 +108,12 @@ exports[`article transformer also works for webcomics (document: webcomics/XK9p2
 
 exports[`article transformer also works for webcomics (document: webcomics/XUGruhEAACYASyJh) 1`] = `
 {
+  "aggregatableValues": {
+    "contributors": [
+      "{"type":"Person","id":"WSQ9rygAAA9xtwfy","label":"Rob Bidder"}",
+    ],
+    "format": "{"type":"ArticleFormat","id":"W7d_ghAAALWY3Ujc","label":"Comic"}",
+  },
   "display": {
     "caption": "They drew it with their feet, one step at a time",
     "contributors": [
@@ -202,6 +214,10 @@ exports[`article transformer also works for webcomics (document: webcomics/XUGru
 
 exports[`article transformer transforms articles from Prismic to the expected format (document: articles/WcvPmSsAAG5B5-ox) 1`] = `
 {
+  "aggregatableValues": {
+    "contributors": [],
+    "format": "{"type":"ArticleFormat","id":"W7TfJRAAAJ1D0eLK","label":"Article"}",
+  },
   "display": {
     "caption": "Elissavet Ntoulia explores what a pair of pomanders can tell us about how and why we remember.",
     "contributors": [],
@@ -325,6 +341,13 @@ exports[`article transformer transforms articles from Prismic to the expected fo
 
 exports[`article transformer transforms articles from Prismic to the expected format (document: articles/Y0U4GBEAAA__16h6) 1`] = `
 {
+  "aggregatableValues": {
+    "contributors": [
+      "{"type":"Person","id":"YvtXgxAAACMA9j5d","label":"Kate Summerscale"}",
+      "{"type":"Person","id":"Yz07IxEAAA__s9BR","label":"Tim Robinson"}",
+    ],
+    "format": "{"type":"ArticleFormat","id":"W8CbPhEAAB8Nq4aG","label":"Book extract"}",
+  },
   "display": {
     "caption": "Kate Summerscale explores the history of our anxieties and compulsions, and the new phobias and manias that are always emerging.",
     "contributors": [
@@ -468,6 +491,12 @@ exports[`article transformer transforms articles from Prismic to the expected fo
 
 exports[`article transformer transforms articles from Prismic to the expected format (document: articles/YbjAThEAACEAcPYF) 1`] = `
 {
+  "aggregatableValues": {
+    "contributors": [
+      "{"type":"Person","id":"W3KvwikAACIAEFVE","label":"Elma Brenner"}",
+    ],
+    "format": "{"type":"ArticleFormat","id":"W7TfJRAAAJ1D0eLK","label":"Article"}",
+  },
   "display": {
     "caption": "With its combination of rich, portable data and high-end style, this folding almanac could have been the medieval equivalent of the latest iPhone.",
     "contributors": [


### PR DESCRIPTION
Big diff *but* it's mostly tests and comments! 😇 

This PR adds aggregations to the content API. The complexity of the change is due to the need to return results that can be used to build a [faceted](https://en.wikipedia.org/wiki/Faceted_search) search interface. The details of those requirements are explained in [RFC 037](https://github.com/wellcomecollection/docs/tree/main/rfcs/037-api-faceting-principles).

The Catalogue API achieves this behaviour through many classes spread across the application, and uses the https://github.com/sksamuel/elastic4s DSL to construct the queries. This code is extremely complex, confusing, and poorly understood (I can say that because I wrote it!)

Most of that code was written during the process of understanding the desired behaviour, rather than after we had a good understanding of requirements: this PR isn't a port of that code to TypeScript but rather it's a rewrite given the understanding we have now. 

A major difference is that I have [reverted](https://github.com/wellcomecollection/catalogue-pipeline/pull/1520) the change that was made in the Catalogue API where we switched from `post_filter` and `min_doc_count: 0` to using the `global` aggregation. It's questionable whether the latter was ever more performant and I think the `post_filter` approach is a clearer statement of intent, and makes for simpler code all round. I also discovered while reading the docs that we can get ES to sort by sug-aggregation for us, removing the need for [reordering](https://github.com/wellcomecollection/catalogue-api/blob/main/search/src/main/scala/weco/api/search/models/Aggregation.scala#L102-L104) responses in the application.

**Interesting bits**
- [Transforming aggregations from ES into our response format](https://github.com/wellcomecollection/content-api/pull/51/files#diff-6bf5f20eed98b41fca5854dac3a9d980e781f811ad40dc011a2002d0faacb15bR12-R42)
- [New fields in the index to aggregate upon](https://github.com/wellcomecollection/content-api/pull/51/files#diff-11bb4100206da7bc8f2c551c3831b624c118128a95951e5427fc79710d76fd27R184-R187)
- [Logic for rewriting standalone aggregations and filters to fulfil facet requirements](https://github.com/wellcomecollection/content-api/pull/51/files#diff-5fd53a7634e25318abd217a9a2171f5abafd4cae08fd5f704757e3b3ba215f71)
- [The actual aggregations we're using](https://github.com/wellcomecollection/content-api/pull/51/files#diff-415d82a7d58b2c8b279d6a6f5e53fee1c4e98e8792c5a072cc264ea423af5f46R48-R66)