### PR TITLE
Make our Prismic imports consistent

### DIFF
--- a/pipeline/src/helpers/index.ts
+++ b/pipeline/src/helpers/index.ts
@@ -1,4 +1,4 @@
-import { KeyTextField, RichTextField } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import * as prismicH from "@prismicio/helpers";
 
 export function isNotUndefined<T>(val: T | undefined): val is T {
@@ -17,7 +17,7 @@ export function isString(v: any): v is string {
  * they add extra validation steps, e.g. removing stray whitespace or null values.
  */
 export function asText(
-  field: KeyTextField | RichTextField
+  field: prismicT.KeyTextField | prismicT.RichTextField
 ): string | undefined {
   if (isString(field)) {
     // KeyTextField
@@ -30,7 +30,7 @@ export function asText(
   }
 }
 
-export function asTitle(title: RichTextField): string {
+export function asTitle(title: prismicT.RichTextField): string {
   // We always need a title - blunt validation, but validation none the less
   return asText(title) || "";
 }

--- a/pipeline/src/helpers/prismic.ts
+++ b/pipeline/src/helpers/prismic.ts
@@ -1,5 +1,5 @@
 import * as prismic from "@prismicio/client";
-import { PrismicDocument } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { TimeWindow } from "../event";
 import {
   bufferCount,
@@ -35,7 +35,7 @@ const fields = {
 export const getPrismicDocuments = async (
   client: prismic.Client,
   { publicationWindow, graphQuery, after }: GetPrismicDocumentsParams
-): Promise<PrismicPage<PrismicDocument>> => {
+): Promise<PrismicPage<prismicT.PrismicDocument>> => {
   const startDate = publicationWindow.start;
   const endDate = publicationWindow.end;
   const docs = await client.get({
@@ -67,7 +67,7 @@ export const getPrismicDocuments = async (
   };
 };
 
-export const paginator = <T extends PrismicDocument>(
+export const paginator = <T extends prismicT.PrismicDocument>(
   nextPage: (after?: string) => Promise<PrismicPage<T>>
 ): Observable<T> =>
   from(nextPage()).pipe(
@@ -75,7 +75,7 @@ export const paginator = <T extends PrismicDocument>(
     concatMap((page) => page.docs)
   );
 
-export const getDocumentsByID = <T extends PrismicDocument>(
+export const getDocumentsByID = <T extends prismicT.PrismicDocument>(
   client: prismic.Client,
   { graphQuery }: { graphQuery?: string } = {}
 ): OperatorFunction<string, T> =>

--- a/pipeline/src/helpers/type-guards.ts
+++ b/pipeline/src/helpers/type-guards.ts
@@ -1,15 +1,15 @@
-import { FilledLinkToDocumentField, RelationField } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { isNotUndefined } from ".";
 import { DataInterface } from "../types";
 
 export function isFilledLinkToDocument<T, L, D extends DataInterface>(
-  field: RelationField<T, L, D> | undefined
-): field is FilledLinkToDocumentField<T, L, D> {
+  field: prismicT.RelationField<T, L, D> | undefined
+): field is prismicT.FilledLinkToDocumentField<T, L, D> {
   return isNotUndefined(field) && "id" in field && field.isBroken === false;
 }
 
 export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
-  field: RelationField<T, L, D> | undefined
-): field is FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
+  field: prismicT.RelationField<T, L, D> | undefined
+): field is prismicT.FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
   return isFilledLinkToDocument(field) && "data" in field;
 }

--- a/pipeline/src/helpers/type-guards.ts
+++ b/pipeline/src/helpers/type-guards.ts
@@ -10,6 +10,8 @@ export function isFilledLinkToDocument<T, L, D extends DataInterface>(
 
 export function isFilledLinkToDocumentWithData<T, L, D extends DataInterface>(
   field: prismicT.RelationField<T, L, D> | undefined
-): field is prismicT.FilledLinkToDocumentField<T, L, D> & { data: DataInterface } {
+): field is prismicT.FilledLinkToDocumentField<T, L, D> & {
+  data: DataInterface;
+} {
   return isFilledLinkToDocument(field) && "data" in field;
 }

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -29,10 +29,10 @@ const getContributors = (
 
       const role = roleDocument
         ? {
-          type: "EditorialContributorRole" as const,
-          id: roleDocument.id as string,
-          label: asText(roleDocument.data.title),
-        }
+            type: "EditorialContributorRole" as const,
+            id: roleDocument.id as string,
+            label: asText(roleDocument.data.title),
+          }
         : undefined;
 
       // CONTRIBUTOR
@@ -42,21 +42,21 @@ const getContributors = (
 
       const contributor = contributorDocument
         ? {
-          type:
-            contributorDocument.type === "people"
-              ? ("Person" as const)
-              : ("Organisation" as const),
-          id: contributorDocument.id as string,
-          label: asText(contributorDocument.data.name),
-        }
+            type:
+              contributorDocument.type === "people"
+                ? ("Person" as const)
+                : ("Organisation" as const),
+            id: contributorDocument.id as string,
+            label: asText(contributorDocument.data.name),
+          }
         : undefined;
 
       return contributor || role
         ? {
-          type: "Contributor",
-          contributor,
-          role,
-        }
+            type: "Contributor",
+            contributor,
+            role,
+          }
         : undefined;
     })
     .filter(isNotUndefined);
@@ -135,16 +135,16 @@ export const transformArticle = (
   const querySeries = data.series.flatMap(({ series }) =>
     isFilledLinkToDocumentWithData(series)
       ? {
-        id: series.id,
-        title: asText(series.data.title),
-        contributors: series.data.contributors
-          .flatMap(({ contributor }) =>
-            isFilledLinkToDocumentWithData(contributor)
-              ? asText(contributor.data.name)
-              : []
-          )
-          .filter(isNotUndefined),
-      }
+          id: series.id,
+          title: asText(series.data.title),
+          contributors: series.data.contributors
+            .flatMap(({ contributor }) =>
+              isFilledLinkToDocumentWithData(contributor)
+                ? asText(contributor.data.name)
+                : []
+            )
+            .filter(isNotUndefined),
+        }
       : []
   );
 

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -11,16 +11,12 @@ import {
 } from "../types";
 import { asText, asTitle, isNotUndefined } from "../helpers";
 import { isFilledLinkToDocumentWithData } from "../helpers/type-guards";
-import {
-  FilledLinkToDocumentField,
-  EmptyImageFieldImage,
-  PrismicDocument,
-} from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { defaultArticleFormat } from "@weco/content-common/data/formats";
 import { linkedDocumentIdentifiers } from "./identifiers";
 
 const getContributors = (
-  document: PrismicDocument<WithContributors>
+  document: prismicT.PrismicDocument<WithContributors>
 ): Contributor[] => {
   const { data } = document;
 
@@ -33,10 +29,10 @@ const getContributors = (
 
       const role = roleDocument
         ? {
-            type: "EditorialContributorRole" as const,
-            id: roleDocument.id as string,
-            label: asText(roleDocument.data.title),
-          }
+          type: "EditorialContributorRole" as const,
+          id: roleDocument.id as string,
+          label: asText(roleDocument.data.title),
+        }
         : undefined;
 
       // CONTRIBUTOR
@@ -46,21 +42,21 @@ const getContributors = (
 
       const contributor = contributorDocument
         ? {
-            type:
-              contributorDocument.type === "people"
-                ? ("Person" as const)
-                : ("Organisation" as const),
-            id: contributorDocument.id as string,
-            label: asText(contributorDocument.data.name),
-          }
+          type:
+            contributorDocument.type === "people"
+              ? ("Person" as const)
+              : ("Organisation" as const),
+          id: contributorDocument.id as string,
+          label: asText(contributorDocument.data.name),
+        }
         : undefined;
 
       return contributor || role
         ? {
-            type: "Contributor",
-            contributor,
-            role,
-          }
+          type: "Contributor",
+          contributor,
+          role,
+        }
         : undefined;
     })
     .filter(isNotUndefined);
@@ -71,13 +67,13 @@ const getContributors = (
 // when images have crops, event if the image isn't attached, we get e.g.
 // { '32:15': {}, '16:9': {}, square: {} }
 function isImageLink(
-  maybeImage: EmptyImageFieldImage | PrismicImage | undefined
+  maybeImage: prismicT.EmptyImageFieldImage | PrismicImage | undefined
 ): maybeImage is PrismicImage {
   return Boolean(maybeImage && maybeImage.dimensions);
 }
 
 function transformLabelType(
-  format: FilledLinkToDocumentField<
+  format: prismicT.FilledLinkToDocumentField<
     "article-formats",
     "en-gb",
     InferDataInterface<PrismicArticleFormat>
@@ -91,7 +87,7 @@ function transformLabelType(
 }
 
 export const isArticle = (
-  doc: PrismicDocument
+  doc: prismicT.PrismicDocument
 ): doc is ArticlePrismicDocument =>
   ["articles", "webcomics"].includes(doc.type);
 
@@ -139,16 +135,16 @@ export const transformArticle = (
   const querySeries = data.series.flatMap(({ series }) =>
     isFilledLinkToDocumentWithData(series)
       ? {
-          id: series.id,
-          title: asText(series.data.title),
-          contributors: series.data.contributors
-            .flatMap(({ contributor }) =>
-              isFilledLinkToDocumentWithData(contributor)
-                ? asText(contributor.data.name)
-                : []
-            )
-            .filter(isNotUndefined),
-        }
+        id: series.id,
+        title: asText(series.data.title),
+        contributors: series.data.contributors
+          .flatMap(({ contributor }) =>
+            isFilledLinkToDocumentWithData(contributor)
+              ? asText(contributor.data.name)
+              : []
+          )
+          .filter(isNotUndefined),
+      }
       : []
   );
 

--- a/pipeline/src/types/prismic/articles.ts
+++ b/pipeline/src/types/prismic/articles.ts
@@ -1,8 +1,4 @@
-import {
-  PrismicDocument,
-  RelationField,
-  TimestampField,
-} from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import {
   WithContributors,
   WithBody,
@@ -13,20 +9,20 @@ import {
 import { WithSeries } from "./series";
 
 type WithArticleFormat = {
-  format: RelationField<
+  format: prismic.RelationField<
     "article-formats",
     "en-gb",
     InferDataInterface<PrismicArticleFormat>
   >;
 };
 
-export type ArticlePrismicDocument = PrismicDocument<
+export type ArticlePrismicDocument = prismic.PrismicDocument<
   {
-    publishDate: TimestampField;
+    publishDate: prismic.TimestampField;
   } & WithContributors &
-    WithArticleFormat &
-    WithBody &
-    WithSeries &
-    CommonPrismicFields,
+  WithArticleFormat &
+  WithBody &
+  WithSeries &
+  CommonPrismicFields,
   "articles" | "webcomics"
 >;

--- a/pipeline/src/types/prismic/articles.ts
+++ b/pipeline/src/types/prismic/articles.ts
@@ -20,9 +20,9 @@ export type ArticlePrismicDocument = prismic.PrismicDocument<
   {
     publishDate: prismic.TimestampField;
   } & WithContributors &
-  WithArticleFormat &
-  WithBody &
-  WithSeries &
-  CommonPrismicFields,
+    WithArticleFormat &
+    WithBody &
+    WithSeries &
+    CommonPrismicFields,
   "articles" | "webcomics"
 >;

--- a/pipeline/src/types/prismic/articles.ts
+++ b/pipeline/src/types/prismic/articles.ts
@@ -9,16 +9,16 @@ import {
 import { WithSeries } from "./series";
 
 type WithArticleFormat = {
-  format: prismic.RelationField<
+  format: prismicT.RelationField<
     "article-formats",
     "en-gb",
     InferDataInterface<PrismicArticleFormat>
   >;
 };
 
-export type ArticlePrismicDocument = prismic.PrismicDocument<
+export type ArticlePrismicDocument = prismicT.PrismicDocument<
   {
-    publishDate: prismic.TimestampField;
+    publishDate: prismicT.TimestampField;
   } & WithContributors &
     WithArticleFormat &
     WithBody &

--- a/pipeline/src/types/prismic/body.ts
+++ b/pipeline/src/types/prismic/body.ts
@@ -1,4 +1,4 @@
-import { GroupField } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 
 type PrismicBody = {
   primary: {
@@ -9,5 +9,5 @@ type PrismicBody = {
 };
 
 export type WithBody = {
-  body?: GroupField<PrismicBody>;
+  body?: prismicT.GroupField<PrismicBody>;
 };

--- a/pipeline/src/types/prismic/contributors.ts
+++ b/pipeline/src/types/prismic/contributors.ts
@@ -3,10 +3,10 @@ import * as prismicT from "@prismicio/types";
 type PrismicContributorContributor =
   | prismicT.EmptyLinkField<"Document">
   | prismicT.FilledLinkToDocumentField<
-    "organisations" | "people",
-    "en-gb",
-    { name: prismicT.RichTextField }
-  >;
+      "organisations" | "people",
+      "en-gb",
+      { name: prismicT.RichTextField }
+    >;
 
 type PrismicContributorRole = prismicT.RelationField<
   "editorial-contributor-roles",

--- a/pipeline/src/types/prismic/contributors.ts
+++ b/pipeline/src/types/prismic/contributors.ts
@@ -1,26 +1,20 @@
-import {
-  EmptyLinkField,
-  FilledLinkToDocumentField,
-  GroupField,
-  RelationField,
-  RichTextField,
-} from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 
 type PrismicContributorContributor =
-  | EmptyLinkField<"Document">
-  | FilledLinkToDocumentField<
-      "organisations" | "people",
-      "en-gb",
-      { name: RichTextField }
-    >;
+  | prismicT.EmptyLinkField<"Document">
+  | prismicT.FilledLinkToDocumentField<
+    "organisations" | "people",
+    "en-gb",
+    { name: prismicT.RichTextField }
+  >;
 
-type PrismicContributorRole = RelationField<
+type PrismicContributorRole = prismicT.RelationField<
   "editorial-contributor-roles",
   "en-gb",
-  { title: RichTextField }
+  { title: prismicT.RichTextField }
 >;
 
-type Contributors = GroupField<{
+type Contributors = prismicT.GroupField<{
   role: PrismicContributorRole;
   contributor: PrismicContributorContributor;
 }>;

--- a/pipeline/src/types/prismic/formats.ts
+++ b/pipeline/src/types/prismic/formats.ts
@@ -1,4 +1,4 @@
-import { PrismicDocument, RichTextField } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import {
   articleFormatIds,
   contentTypes,
@@ -9,9 +9,9 @@ export type ContentType = (typeof contentTypes)[number];
 export type ArticleFormatId =
   (typeof articleFormatIds)[keyof typeof articleFormatIds];
 
-export type PrismicArticleFormat = PrismicDocument<
+export type PrismicArticleFormat = prismicT.PrismicDocument<
   {
-    title: RichTextField;
+    title: prismicT.RichTextField;
   },
   "article-formats"
 >;

--- a/pipeline/src/types/prismic/images.ts
+++ b/pipeline/src/types/prismic/images.ts
@@ -1,10 +1,10 @@
-import { FilledImageFieldImage } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { ImageDimensions } from "..";
 
 // Currently the Prismic types only allow you to specify 1 image
 type ThumbnailedImageField<Thumbnails extends Record<string, ImageDimensions>> =
-  FilledImageFieldImage & {
-    [Property in keyof Thumbnails]?: FilledImageFieldImage;
+  prismicT.FilledImageFieldImage & {
+    [Property in keyof Thumbnails]?: prismicT.FilledImageFieldImage;
   };
 
 export type PrismicImage = ThumbnailedImageField<{

--- a/pipeline/src/types/prismic/index.ts
+++ b/pipeline/src/types/prismic/index.ts
@@ -23,7 +23,9 @@ export type InferDataInterface<T> = T extends prismicT.PrismicDocument<
   : never;
 
 type Promo = { caption: prismicT.RichTextField; image: PrismicImage };
-export type PromoSliceZone = prismicT.SliceZone<prismicT.Slice<"editorialImage", Promo>>;
+export type PromoSliceZone = prismicT.SliceZone<
+  prismicT.Slice<"editorialImage", Promo>
+>;
 
 export type CommonPrismicFields = {
   title: prismicT.RichTextField;

--- a/pipeline/src/types/prismic/index.ts
+++ b/pipeline/src/types/prismic/index.ts
@@ -1,11 +1,4 @@
-import {
-  AnyRegularField,
-  GroupField,
-  PrismicDocument,
-  RichTextField,
-  Slice,
-  SliceZone,
-} from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { PrismicImage } from "..";
 
 /**
@@ -13,7 +6,7 @@ import { PrismicImage } from "..";
  */
 export type DataInterface = Record<
   string,
-  AnyRegularField | GroupField | SliceZone
+  prismicT.AnyRegularField | prismicT.GroupField | prismicT.SliceZone
 >;
 
 /**
@@ -23,16 +16,16 @@ export type DataInterface = Record<
  * type DataInterface = InferDataInterface<Doc> // { title: RichTextField }
  * RelationField<'formats', 'en-gb', DataInterface>
  */
-export type InferDataInterface<T> = T extends PrismicDocument<
+export type InferDataInterface<T> = T extends prismicT.PrismicDocument<
   infer DataInterface
 >
   ? DataInterface
   : never;
 
-type Promo = { caption: RichTextField; image: PrismicImage };
-export type PromoSliceZone = SliceZone<Slice<"editorialImage", Promo>>;
+type Promo = { caption: prismicT.RichTextField; image: PrismicImage };
+export type PromoSliceZone = prismicT.SliceZone<prismicT.Slice<"editorialImage", Promo>>;
 
 export type CommonPrismicFields = {
-  title: RichTextField;
+  title: prismicT.RichTextField;
   promo: PromoSliceZone;
 };

--- a/pipeline/src/types/prismic/series.ts
+++ b/pipeline/src/types/prismic/series.ts
@@ -5,12 +5,12 @@ export type WithSeries = {
   series: Series;
 };
 
-type Series = GroupField<{
+type Series = prismicT.GroupField<{
   series: PrismicSeries;
 }>;
 
-type PrismicSeries = RelationField<
+type PrismicSeries = prismicT.RelationField<
   "webcomic-series" | "series",
   "en-gb",
-  { title: RichTextField } & WithContributors
+  { title: prismicT.RichTextField } & WithContributors
 >;

--- a/pipeline/src/types/prismic/series.ts
+++ b/pipeline/src/types/prismic/series.ts
@@ -1,4 +1,4 @@
-import { GroupField, RelationField, RichTextField } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { WithContributors } from "./contributors";
 
 export type WithSeries = {

--- a/pipeline/test/fixtures/prismic-snapshots.ts
+++ b/pipeline/test/fixtures/prismic-snapshots.ts
@@ -28,11 +28,11 @@ const snapshotNamesForContentType = (prismicType: PrismicType): string[] =>
   prismicTypesCache.get(prismicType) ??
   fs.readdirSync(dataDir).filter((f) => f.endsWith(`${prismicType}.json`));
 
-export const getSnapshots = <T extends prismic.PrismicDocument>(
+export const getSnapshots = <T extends prismicT.PrismicDocument>(
   ...prismicTypes: PrismicType[]
 ): T[] => prismicTypes.flatMap(snapshotNamesForContentType).map(getSnapshot<T>);
 
-export const forEachPrismicSnapshot = <T extends prismic.PrismicDocument>(
+export const forEachPrismicSnapshot = <T extends prismicT.PrismicDocument>(
   ...prismicTypes: PrismicType[]
 ) => {
   const snapshots = getSnapshots<T>(...prismicTypes);

--- a/pipeline/test/fixtures/prismic-snapshots.ts
+++ b/pipeline/test/fixtures/prismic-snapshots.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { test } from "@jest/globals";
 import type { Global as JestGlobal } from "@jest/types";
 import { ContentType } from "../../src/types";
-import { PrismicDocument } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 
 // For prismic types which we do not make addressable but are included in our other documents
 type NonAddressableContentType = "people";
@@ -28,11 +28,11 @@ const snapshotNamesForContentType = (prismicType: PrismicType): string[] =>
   prismicTypesCache.get(prismicType) ??
   fs.readdirSync(dataDir).filter((f) => f.endsWith(`${prismicType}.json`));
 
-export const getSnapshots = <T extends PrismicDocument>(
+export const getSnapshots = <T extends prismic.PrismicDocument>(
   ...prismicTypes: PrismicType[]
 ): T[] => prismicTypes.flatMap(snapshotNamesForContentType).map(getSnapshot<T>);
 
-export const forEachPrismicSnapshot = <T extends PrismicDocument>(
+export const forEachPrismicSnapshot = <T extends prismic.PrismicDocument>(
   ...prismicTypes: PrismicType[]
 ) => {
   const snapshots = getSnapshots<T>(...prismicTypes);

--- a/pipeline/test/fixtures/prismic.ts
+++ b/pipeline/test/fixtures/prismic.ts
@@ -1,6 +1,6 @@
-import { PrismicDocument } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 
-export const prismicGet = <T extends PrismicDocument>(docs: T[]) =>
+export const prismicGet = <T extends prismicT.PrismicDocument>(docs: T[]) =>
   jest
     .fn()
     .mockResolvedValueOnce({ results: docs })

--- a/pipeline/test/handler.test.ts
+++ b/pipeline/test/handler.test.ts
@@ -1,5 +1,5 @@
 import type { Client as ElasticClient } from "@elastic/elasticsearch";
-import type { Client as PrismicClient } from "@prismicio/client";
+import * as prismic from "@prismicio/client";
 import { createHandler } from "../src/handler";
 import { Context } from "aws-lambda";
 import { ArticlePrismicDocument } from "../src/types";
@@ -28,7 +28,7 @@ describe("handler", () => {
 
     const prismicClient = {
       get: prismicGet(allDocs),
-    } as unknown as PrismicClient;
+    } as unknown as prismic.Client;
 
     const testHandler = createHandler({
       elastic: elasticClient,
@@ -67,7 +67,7 @@ describe("handler", () => {
     const prismicClient = {
       get: prismicGet(contributors),
       getByIDs: prismicGetByIDs,
-    } as unknown as PrismicClient;
+    } as unknown as prismic.Client;
 
     const elasticIndexCreator = jest.fn().mockResolvedValue(true);
     const [elasticBulkHelper, getIndexedDocuments] = createElasticBulkHelper();

--- a/pipeline/test/prismic-helpers.test.ts
+++ b/pipeline/test/prismic-helpers.test.ts
@@ -1,5 +1,5 @@
 import * as prismic from "@prismicio/client";
-import { PrismicDocument } from "@prismicio/types";
+import * as prismicT from "@prismicio/types";
 import { lastValueFrom, of } from "rxjs";
 import { getDocumentsByID, paginator } from "../src/helpers/prismic";
 import { identifiedDocuments } from "./fixtures/generators";
@@ -10,7 +10,7 @@ describe("paginator", () => {
     const pageSize = 10;
     const allThings = identifiedDocuments(
       totalDocs
-    ) as unknown as PrismicDocument[];
+    ) as unknown as prismicT.PrismicDocument[];
     const nextPage = jest.fn((after?: string) => {
       const idx = after ? allThings.findIndex((doc) => doc.id === after) : 0;
       return Promise.resolve({


### PR DESCRIPTION
We've switched to namespacing everything in the front-end; let's do the same here.

For https://github.com/wellcomecollection/wellcomecollection.org/issues/9797