### PR TITLE
Add service permissions for `events*` indices

### DIFF
--- a/infrastructure/pipeline_stack/elastic_users.tf
+++ b/infrastructure/pipeline_stack/elastic_users.tf
@@ -1,17 +1,22 @@
 locals {
   indices = {
     articles = "articles"
+    events   = "events"
   }
   service_roles = {
     api = [
-      "${local.indices.articles}_read"
+      "${local.indices.articles}_read",
+      "${local.indices.events}_read",
     ]
     pipeline = [
       "${local.indices.articles}_read",
-      "${local.indices.articles}_write"
+      "${local.indices.articles}_write",
+      "${local.indices.events}_read",
+      "${local.indices.events}_write"
     ]
     unpublisher = [
-      "${local.indices.articles}_write"
+      "${local.indices.articles}_write",
+      "${local.indices.events}_write"
     ]
   }
 }


### PR DESCRIPTION
This will prevent pain further down the line. It's already applied.