### PR TITLE
Single event endpoint

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -11,7 +11,8 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2023-03-24",
-  contentsIndex: "articles",
+  articlesIndex: "articles",
+  eventsIndex: "events",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/api/config.ts
+++ b/api/config.ts
@@ -11,7 +11,9 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2023-03-24",
-  contentsIndex: "articles",
+  articlesIndex: "articles",
+  eventsIndex: "events",
+  // contentsIndex: "articles",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/api/config.ts
+++ b/api/config.ts
@@ -12,8 +12,10 @@ const environment = environmentSchema.parse(process.env);
 const config = {
   pipelineDate: "2023-03-24",
   articlesIndex: "articles",
-  eventsIndex: "events",
-  // contentsIndex: "articles",
+  eventsIndex: "events-test",
+  // eventsIndex: "events-test"
+  // test data with data under id abc123
+  // use GET /events/abc123
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/api/config.ts
+++ b/api/config.ts
@@ -11,8 +11,7 @@ const environment = environmentSchema.parse(process.env);
 
 const config = {
   pipelineDate: "2023-03-24",
-  articlesIndex: "articles",
-  eventsIndex: "events",
+  contentsIndex: "articles",
   publicRootUrl: new URL(environment.PUBLIC_ROOT_URL),
 };
 

--- a/api/config.ts
+++ b/api/config.ts
@@ -12,7 +12,7 @@ const environment = environmentSchema.parse(process.env);
 const config = {
   pipelineDate: "2023-03-24",
   articlesIndex: "articles",
-  eventsIndex: "events-test",
+  eventsIndex: "events",
   // eventsIndex: "events-test"
   // test data with data under id abc123
   // use GET /events/abc123

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -5,6 +5,7 @@ import {
   errorHandler,
   articlesController,
   articleController,
+  eventController,
 } from "./controllers";
 import { Config } from "../config";
 import { Clients } from "./types";
@@ -16,6 +17,8 @@ const createApp = (clients: Clients, config: Config) => {
 
   app.get("/articles", articlesController(clients, config));
   app.get("/articles/:id", articleController(clients, config));
+
+  app.get("/events/:id", eventController(clients, config));
 
   app.use(errorHandler);
 

--- a/api/src/controllers/article.ts
+++ b/api/src/controllers/article.ts
@@ -11,7 +11,7 @@ const articleController = (
   clients: Clients,
   config: Config
 ): RequestHandler<PathParams> => {
-  const index = config.articlesIndex;
+  const index = config.contentsIndex;
 
   return asyncHandler(async (req, res) => {
     const id = req.params.id;

--- a/api/src/controllers/article.ts
+++ b/api/src/controllers/article.ts
@@ -12,7 +12,6 @@ const articleController = (
   config: Config
 ): RequestHandler<PathParams> => {
   const index = config.articlesIndex;
-  // const index = config.contentsIndex;
 
   return asyncHandler(async (req, res) => {
     const id = req.params.id;

--- a/api/src/controllers/article.ts
+++ b/api/src/controllers/article.ts
@@ -11,7 +11,7 @@ const articleController = (
   clients: Clients,
   config: Config
 ): RequestHandler<PathParams> => {
-  const index = config.contentsIndex;
+  const index = config.articlesIndex;
 
   return asyncHandler(async (req, res) => {
     const id = req.params.id;

--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -58,7 +58,8 @@ const articlesController = (
   clients: Clients,
   config: Config
 ): ArticlesHandler => {
-  const index = config.contentsIndex;
+  const index = config.articlesIndex;
+  // const index = config.contentsIndex;
   const resultList = resultListResponse(config);
 
   return asyncHandler(async (req, res) => {

--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -59,7 +59,6 @@ const articlesController = (
   config: Config
 ): ArticlesHandler => {
   const index = config.articlesIndex;
-  // const index = config.contentsIndex;
   const resultList = resultListResponse(config);
 
   return asyncHandler(async (req, res) => {

--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -58,7 +58,7 @@ const articlesController = (
   clients: Clients,
   config: Config
 ): ArticlesHandler => {
-  const index = config.articlesIndex;
+  const index = config.contentsIndex;
   const resultList = resultListResponse(config);
 
   return asyncHandler(async (req, res) => {

--- a/api/src/controllers/articles.ts
+++ b/api/src/controllers/articles.ts
@@ -58,7 +58,7 @@ const articlesController = (
   clients: Clients,
   config: Config
 ): ArticlesHandler => {
-  const index = config.contentsIndex;
+  const index = config.articlesIndex;
   const resultList = resultListResponse(config);
 
   return asyncHandler(async (req, res) => {

--- a/api/src/controllers/error.ts
+++ b/api/src/controllers/error.ts
@@ -47,7 +47,7 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     res.status(err.status).json(err.responseJson);
   } else {
     // Log this to prevent it getting swallowed
-    log.error(err);
+    console.error(err);
     // if (apm.isStarted()) {
     //   apm.captureError(err);
     // }

--- a/api/src/controllers/event.ts
+++ b/api/src/controllers/event.ts
@@ -7,12 +7,11 @@ import { HttpError } from "./error";
 
 type PathParams = { id: string };
 
-const articleController = (
+const eventController = (
   clients: Clients,
   config: Config
 ): RequestHandler<PathParams> => {
-  const index = config.articlesIndex;
-  // const index = config.contentsIndex;
+  const index = config.eventsIndex;
 
   return asyncHandler(async (req, res) => {
     const id = req.params.id;
@@ -30,7 +29,7 @@ const articleController = (
           throw new HttpError({
             status: 404,
             label: "Not Found",
-            description: `Article not found for identifier ${id}`,
+            description: `Event not found for identifier ${id}`,
           });
         }
       }
@@ -39,4 +38,4 @@ const articleController = (
   });
 };
 
-export default articleController;
+export default eventController;

--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -1,0 +1,1 @@
+// events.ts

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,5 +1,6 @@
 import articlesController from "./articles";
 import articleController from "./article";
+import eventController from "./event";
 
 export { errorHandler } from "./error";
-export { articlesController, articleController };
+export { articlesController, articleController, eventController };

--- a/api/test/event.test.ts
+++ b/api/test/event.test.ts
@@ -1,0 +1,20 @@
+import { mockedApi } from "./fixtures/api";
+
+describe("GET /events/:id", () => {
+  it("returns a document for the given ID", async () => {
+    const testId = "abc";
+    const testDoc = { title: "test-event" };
+    const api = mockedApi([{ id: testId, display: testDoc }]);
+
+    const response = await api.get(`/events/${testId}`);
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toStrictEqual(testDoc);
+  });
+
+  it("returns a 404 if no document for the given ID exists", async () => {
+    const api = mockedApi([]);
+
+    const response = await api.get(`/events/abc`);
+    expect(response.statusCode).toBe(404);
+  });
+});

--- a/api/test/fixtures/api.ts
+++ b/api/test/fixtures/api.ts
@@ -63,8 +63,9 @@ export const mockedApi = <T extends Displayable & Identified>(
     },
     {
       pipelineDate: "2222-22-22",
-      contentsIndex: testIndex,
+      articlesIndex: testIndex,
       publicRootUrl: new URL("http://test.test/test"),
+      eventsIndex: "",
     }
   );
 

--- a/api/test/fixtures/api.ts
+++ b/api/test/fixtures/api.ts
@@ -63,7 +63,9 @@ export const mockedApi = <T extends Displayable & Identified>(
     },
     {
       pipelineDate: "2222-22-22",
-      contentsIndex: testIndex,
+      articlesIndex: testIndex,
+      eventsIndex: testIndex,
+      // contentsIndex: testIndex,
       publicRootUrl: new URL("http://test.test/test"),
     }
   );

--- a/api/test/fixtures/api.ts
+++ b/api/test/fixtures/api.ts
@@ -63,9 +63,8 @@ export const mockedApi = <T extends Displayable & Identified>(
     },
     {
       pipelineDate: "2222-22-22",
-      articlesIndex: testIndex,
+      contentsIndex: testIndex,
       publicRootUrl: new URL("http://test.test/test"),
-      eventsIndex: "",
     }
   );
 

--- a/api/test/fixtures/api.ts
+++ b/api/test/fixtures/api.ts
@@ -65,7 +65,6 @@ export const mockedApi = <T extends Displayable & Identified>(
       pipelineDate: "2222-22-22",
       articlesIndex: testIndex,
       eventsIndex: testIndex,
-      // contentsIndex: testIndex,
       publicRootUrl: new URL("http://test.test/test"),
     }
   );

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -61,7 +61,7 @@ const elasticsearchRequestForURL = async (
     { elastic: { search: searchSpy } as unknown as ElasticClient },
     {
       pipelineDate: "2222-22-22",
-      articlesIndex: "test",
+      contentsIndex: "test",
       publicRootUrl: new URL("http://test.test/test"),
     }
   );

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -61,7 +61,7 @@ const elasticsearchRequestForURL = async (
     { elastic: { search: searchSpy } as unknown as ElasticClient },
     {
       pipelineDate: "2222-22-22",
-      contentsIndex: "test",
+      articlesIndex: "test",
       publicRootUrl: new URL("http://test.test/test"),
     }
   );

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -61,7 +61,9 @@ const elasticsearchRequestForURL = async (
     { elastic: { search: searchSpy } as unknown as ElasticClient },
     {
       pipelineDate: "2222-22-22",
-      contentsIndex: "test",
+      // contentsIndex: "test",
+      articlesIndex: "test",
+      eventsIndex: "",
       publicRootUrl: new URL("http://test.test/test"),
     }
   );

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -61,7 +61,6 @@ const elasticsearchRequestForURL = async (
     { elastic: { search: searchSpy } as unknown as ElasticClient },
     {
       pipelineDate: "2222-22-22",
-      // contentsIndex: "test",
       articlesIndex: "test",
       eventsIndex: "",
       publicRootUrl: new URL("http://test.test/test"),


### PR DESCRIPTION
### As detailed in #68

- The content-api now expects multiple indices:
  - `contentsIndex` is now split into `articlesIndex` and `eventsIndex`
---

- There is a controller for events, following the same article logic:
  - `controllers/event.ts`

---

- A route for `/event:id` is in the `app.ts`:
  - a call to `/events/:id` correctly 404s with no index yet in place

```json
{
  "type": "Error",
  "httpStatus": 404,
  "label": "Not Found",
  "description": "Event not found for identifier xx",
  "errorType": "http"
}
```

---

- A test data index is in place (requires config to be adjusted to call `"events-test"`) which returns a test event under id: `abc123`:
```json
{
  "type": "Event",
  "id": "abc123",
  "title": "Test Event",
  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
}
```
---

- A test similar to `article.test.ts` is in place and passes for events:
  - `event.test.ts` returns a document for the given id and returns a 404 if no document for the id exists
 
