### PR TITLE
Endpoint for listing all /events 

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -6,6 +6,7 @@ import {
   articlesController,
   articleController,
   eventController,
+  eventsController,
 } from "./controllers";
 import { Config } from "../config";
 import { Clients } from "./types";
@@ -17,7 +18,7 @@ const createApp = (clients: Clients, config: Config) => {
 
   app.get("/articles", articlesController(clients, config));
   app.get("/articles/:id", articleController(clients, config));
-
+  app.get("/events", eventsController(clients, config));
   app.get("/events/:id", eventController(clients, config));
 
   app.use(errorHandler);

--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -4,23 +4,9 @@ import asyncHandler from "express-async-handler";
 import { Clients, Displayable } from "../types";
 import { PaginationQueryParameters, paginationElasticBody } from "./pagination";
 import { Config } from "../../config";
-import {
-  articlesAggregations,
-  articlesFilter,
-  articlesQuery,
-} from "../queries/articles";
-import { queryValidator, validateDate } from "./validation";
-import { ifDefined, pick } from "../helpers";
 import { HttpError } from "./error";
 import { ResultList } from "../types/responses";
 import { resultListResponse } from "../helpers/responses";
-import { AggregationsAggregate } from "@elastic/elasticsearch/lib/api/types";
-import {
-  partitionFiltersForFacets,
-  rewriteAggregationsForFacets,
-} from "../queries/faceting";
-import { esQuery } from "../queries/common";
-import { pickFiltersFromQuery } from "../helpers/requests";
 
 type QueryParams = {
   query?: string;
@@ -35,75 +21,12 @@ type QueryParams = {
 
 type EventsHandler = RequestHandler<never, ResultList, never, QueryParams>;
 
-const sortValidator = queryValidator({
-  name: "sort",
-  defaultValue: "relevance",
-  allowed: ["relevance", "publicationDate"],
-  singleValue: true,
-});
-
-const sortOrderValidator = queryValidator({
-  name: "sortOrder",
-  defaultValue: "desc",
-  allowed: ["asc", "desc"],
-  singleValue: true,
-});
-
 const eventsController = (clients: Clients, config: Config): EventsHandler => {
   const index = config.eventsIndex;
   const resultList = resultListResponse(config);
 
-  // return asyncHandler(async (req, res) => {
-
-  //   const sortKey =
-  //     sort === "publicationDate" ? "query.publicationDate" : "_score";
-
-  //   try {
-  //     const searchResponse = await clients.elastic.search<
-  //       Displayable
-  //     >({
-  //       index,
-  //       _source: ["display"],
-  //       query: {
-  //         bool: {
-  //           must: ifDefined(queryString, articlesQuery),
-
-  //         },
-  //       },
-  //       sort: [
-  //         { [sortKey]: { order: sortOrder } },
-  //         // Use recency as a "tie-breaker" sort
-  //         { "query.publicationDate": { order: "desc" } },
-  //       ],
-  //       ...paginationElasticBody(req.query),
-  //     });
-
-  //     res.status(200).json(resultList(req, searchResponse));
-  //   } catch (e) {
-  //     if (
-  //       e instanceof elasticErrors.ResponseError &&
-  //       // This is an error we see from very long (spam) queries which contain
-  //       // many many terms and so overwhelm the multi_match query. The check
-  //       // for length is a heuristic so that if we get legitimate `too_many_nested_clauses`
-  //       // errors, we're still alerted to them
-  //       e.message.includes("too_many_nested_clauses") &&
-  //       encodeURIComponent(queryString || "").length > 2000
-  //     ) {
-  //       throw new HttpError({
-  //         status: 400,
-  //         label: "Bad Request",
-  //         description:
-  //           "Your query contained too many terms, please try again with a simpler query",
-  //       });
-  //     }
-  //     throw e;
-  //   }
-  // });
-
   return asyncHandler(async (req, res) => {
     const { query: queryString, ...params } = req.query;
-    const sort = sortValidator(params)?.[0];
-    const sortOrder = sortOrderValidator(params)?.[0];
     try {
       const searchResponse = await clients.elastic.search<Displayable>({
         index,

--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -1,1 +1,129 @@
-// events.ts
+import { errors as elasticErrors } from "@elastic/elasticsearch";
+import { RequestHandler } from "express";
+import asyncHandler from "express-async-handler";
+import { Clients, Displayable } from "../types";
+import { PaginationQueryParameters, paginationElasticBody } from "./pagination";
+import { Config } from "../../config";
+import {
+  articlesAggregations,
+  articlesFilter,
+  articlesQuery,
+} from "../queries/articles";
+import { queryValidator, validateDate } from "./validation";
+import { ifDefined, pick } from "../helpers";
+import { HttpError } from "./error";
+import { ResultList } from "../types/responses";
+import { resultListResponse } from "../helpers/responses";
+import { AggregationsAggregate } from "@elastic/elasticsearch/lib/api/types";
+import {
+  partitionFiltersForFacets,
+  rewriteAggregationsForFacets,
+} from "../queries/faceting";
+import { esQuery } from "../queries/common";
+import { pickFiltersFromQuery } from "../helpers/requests";
+
+type QueryParams = {
+  query?: string;
+  sort?: string;
+  sortOrder?: string;
+  aggregations?: string;
+  "contributors.contributor"?: string;
+  "publicationDate.from"?: string;
+  "publicationDate.to"?: string;
+  format?: string;
+} & PaginationQueryParameters;
+
+type EventsHandler = RequestHandler<never, ResultList, never, QueryParams>;
+
+const sortValidator = queryValidator({
+  name: "sort",
+  defaultValue: "relevance",
+  allowed: ["relevance", "publicationDate"],
+  singleValue: true,
+});
+
+const sortOrderValidator = queryValidator({
+  name: "sortOrder",
+  defaultValue: "desc",
+  allowed: ["asc", "desc"],
+  singleValue: true,
+});
+
+const eventsController = (clients: Clients, config: Config): EventsHandler => {
+  const index = config.eventsIndex;
+  const resultList = resultListResponse(config);
+
+  // return asyncHandler(async (req, res) => {
+
+  //   const sortKey =
+  //     sort === "publicationDate" ? "query.publicationDate" : "_score";
+
+  //   try {
+  //     const searchResponse = await clients.elastic.search<
+  //       Displayable
+  //     >({
+  //       index,
+  //       _source: ["display"],
+  //       query: {
+  //         bool: {
+  //           must: ifDefined(queryString, articlesQuery),
+
+  //         },
+  //       },
+  //       sort: [
+  //         { [sortKey]: { order: sortOrder } },
+  //         // Use recency as a "tie-breaker" sort
+  //         { "query.publicationDate": { order: "desc" } },
+  //       ],
+  //       ...paginationElasticBody(req.query),
+  //     });
+
+  //     res.status(200).json(resultList(req, searchResponse));
+  //   } catch (e) {
+  //     if (
+  //       e instanceof elasticErrors.ResponseError &&
+  //       // This is an error we see from very long (spam) queries which contain
+  //       // many many terms and so overwhelm the multi_match query. The check
+  //       // for length is a heuristic so that if we get legitimate `too_many_nested_clauses`
+  //       // errors, we're still alerted to them
+  //       e.message.includes("too_many_nested_clauses") &&
+  //       encodeURIComponent(queryString || "").length > 2000
+  //     ) {
+  //       throw new HttpError({
+  //         status: 400,
+  //         label: "Bad Request",
+  //         description:
+  //           "Your query contained too many terms, please try again with a simpler query",
+  //       });
+  //     }
+  //     throw e;
+  //   }
+  // });
+
+  return asyncHandler(async (req, res) => {
+    const { query: queryString, ...params } = req.query;
+    const sort = sortValidator(params)?.[0];
+    const sortOrder = sortOrderValidator(params)?.[0];
+    try {
+      const searchResponse = await clients.elastic.search<Displayable>({
+        index,
+        _source: ["display"],
+      });
+
+      res.status(200).json(resultList(req, searchResponse));
+    } catch (error) {
+      if (error instanceof elasticErrors.ResponseError) {
+        if (error.statusCode === 404) {
+          throw new HttpError({
+            status: 404,
+            label: "Not Found",
+            description: `No events`,
+          });
+        }
+      }
+      throw error;
+    }
+  });
+};
+
+export default eventsController;

--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -2,7 +2,7 @@ import { errors as elasticErrors } from "@elastic/elasticsearch";
 import { RequestHandler } from "express";
 import asyncHandler from "express-async-handler";
 import { Clients, Displayable } from "../types";
-import { PaginationQueryParameters, paginationElasticBody } from "./pagination";
+import { PaginationQueryParameters } from "./pagination";
 import { Config } from "../../config";
 import { HttpError } from "./error";
 import { ResultList } from "../types/responses";

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,6 +1,12 @@
 import articlesController from "./articles";
 import articleController from "./article";
 import eventController from "./event";
+import eventsController from "./events";
 
 export { errorHandler } from "./error";
-export { articlesController, articleController, eventController };
+export {
+  articlesController,
+  articleController,
+  eventController,
+  eventsController,
+};

--- a/api/test/events.test.ts
+++ b/api/test/events.test.ts
@@ -1,0 +1,17 @@
+import { mockedApi } from "./fixtures/api";
+
+describe("GET /events", () => {
+  it("returns a list of events", async () => {
+    const events = Array.from({ length: 10 }).map((_, i) => ({
+      id: `id-${i}`,
+      display: {
+        title: `test event ${i}`,
+      },
+    }));
+    const api = mockedApi(events);
+
+    const response = await api.get(`/events`);
+    expect(response.statusCode).toBe(200);
+    expect(response.body.results).toStrictEqual(events.map((x) => x.display));
+  });
+});


### PR DESCRIPTION
Following on from #68, this covers #67 

- An `eventsController` in `controller/events.ts` has been created to request, fetch, and list all events. 

![image](https://github.com/wellcomecollection/content-api/assets/81175151/7812340d-6f94-4687-b78d-1280b553efd8)

Using the test data from #68 - results page looks like: 

```JSON
{
  "type": "ResultList",
  "results": [
    {
      "type": "Event",
      "id": "abc123",
      "title": "Test Event",
      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
    },
    {
      "type": "Event",
      "id": "def456",
      "title": "Test Event 2 - Multiple",
      "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
    }
  ],
  "pageSize": 10,
  "totalPages": 1,
  "totalResults": 2
}
```

---

- A test was created in `events.test.ts` to check GET functionality for `/events` to ensure that the endpoint correctly returns a list of event data.

---

- `app.ts` was accordingly updated to route to `/events`