### PR TITLE
Fixes sorting asc/desc order

### DIFF
--- a/pipeline/src/indices/events.ts
+++ b/pipeline/src/indices/events.ts
@@ -1,6 +1,9 @@
+import { IndicesIndexSettings } from "@elastic/elasticsearch/lib/api/types";
+
 export const index = "events";
 
 export const mappings = {
+  dynamic: "strict",
   properties: {
     id: {
       type: "keyword",
@@ -11,6 +14,76 @@ export const mappings = {
     },
     query: {
       properties: {
+        linkedIdentifiers: {
+          type: "keyword",
+        },
+        title: {
+          type: "text",
+          fields: {
+            shingles: {
+              type: "text",
+              analyzer: "english_shingle_analyzer",
+            },
+            cased: {
+              type: "text",
+              analyzer: "english_cased_analyzer",
+            },
+            keyword: {
+              type: "keyword",
+              normalizer: "keyword_lowercase",
+            },
+          },
+        },
+        caption: {
+          type: "text",
+          fields: {
+            shingles: {
+              type: "text",
+              analyzer: "english_shingle_analyzer",
+            },
+            cased: {
+              type: "text",
+              analyzer: "english_cased_analyzer",
+            },
+          },
+        },
+        series: {
+          properties: {
+            id: {
+              type: "keyword",
+            },
+            title: {
+              type: "text",
+              fields: {
+                shingles: {
+                  type: "text",
+                  analyzer: "english_shingle_analyzer",
+                },
+                cased: {
+                  type: "text",
+                  analyzer: "english_cased_analyzer",
+                },
+                keyword: {
+                  type: "keyword",
+                  normalizer: "keyword_lowercase",
+                },
+              },
+            },
+            contributors: {
+              type: "text",
+              fields: {
+                shingles: {
+                  type: "text",
+                  analyzer: "english_shingle_analyzer",
+                },
+                keyword: {
+                  type: "keyword",
+                  normalizer: "keyword_lowercase",
+                },
+              },
+            },
+          },
+        },
         "times.startDateTime": {
           type: "date",
           format: "date_optional_time",
@@ -20,4 +93,58 @@ export const mappings = {
   },
 } as const;
 
-export const settings = {};
+export const settings = {
+  analysis: {
+    normalizer: {
+      keyword_lowercase: {
+        type: "custom",
+        filter: ["lowercase"],
+      },
+    },
+    filter: {
+      shingle_filter: {
+        type: "shingle",
+        min_shingle_size: 2,
+        max_shingle_size: 4,
+        output_unigrams: true,
+      },
+      english_stemmer: {
+        type: "stemmer",
+        language: "english",
+      },
+      english_possessive_stemmer: {
+        type: "stemmer",
+        language: "possessive_english",
+      },
+      punctuation_token_filter: {
+        type: "pattern_replace",
+        pattern: "[^0-9\\p{L}\\s]",
+        replacement: "",
+      },
+    },
+    analyzer: {
+      english_shingle_analyzer: {
+        filter: [
+          "lowercase",
+          "asciifolding",
+          "english_stemmer",
+          "english_possessive_stemmer",
+          "punctuation_token_filter",
+          "shingle_filter",
+        ],
+        type: "custom",
+        tokenizer: "standard",
+      },
+      english_cased_analyzer: {
+        filter: [
+          "asciifolding",
+          "english_stemmer",
+          "english_possessive_stemmer",
+          "punctuation_token_filter",
+        ],
+        type: "custom",
+        tokenizer: "standard",
+      },
+    },
+  },
+} as IndicesIndexSettings; // as const was not sufficient, here.

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -97,6 +97,8 @@ export const transformEventDocument = (
     id,
   } = document;
 
+  const documentTimes = document.data.times;
+
   const primaryImage = promo?.[0]?.primary;
   const image =
     primaryImage && isImageLink(primaryImage.image)
@@ -126,6 +128,13 @@ export const transformEventDocument = (
       title: asTitle(title),
       caption: primaryImage?.caption && asText(primaryImage.caption),
       series: formatSeriesForQuery(document),
+      times: {
+        startDateTime: documentTimes
+          .map((time) =>
+            time.startDateTime ? new Date(time.startDateTime) : null
+          )
+          .filter((date): date is Date => date !== null),
+      },
     },
   };
 };

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -97,7 +97,7 @@ export const transformEventDocument = (
     id,
   } = document;
 
-  const documentTimes = document.data.times;
+  const documentTimes = times.map(prismicTimestampToDate);
 
   const primaryImage = promo?.[0]?.primary;
   const image =
@@ -130,10 +130,8 @@ export const transformEventDocument = (
       series: formatSeriesForQuery(document),
       times: {
         startDateTime: documentTimes
-          .map((time) =>
-            time.startDateTime ? new Date(time.startDateTime) : null
-          )
-          .filter((date): date is Date => date !== null),
+          .map((time) => time.startDateTime)
+          .filter(isNotUndefined),
       },
     },
   };

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -1,3 +1,4 @@
+import { TimestampField } from "@prismicio/client/*";
 import { PrismicImage } from "../prismic";
 import { Article, ArticleFormat } from "../transformed/article";
 import {
@@ -75,5 +76,6 @@ export type ElasticsearchEventDocument = {
     title: string;
     caption?: string;
     series: QuerySeries;
+    times: { startDateTime: Date[] };
   };
 };

--- a/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
@@ -134,6 +134,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "title": "Land Body Ecologies Festival",
       },
     ],
+    "times": {
+      "startDateTime": [
+        2023-06-23T09:00:00.000Z,
+      ],
+    },
     "title": "Land Body Ecologies Festival Day Two",
   },
 }
@@ -254,6 +259,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "title": "Perspective Tours",
       },
     ],
+    "times": {
+      "startDateTime": [
+        2023-08-24T16:30:00.000Z,
+      ],
+    },
     "title": "Perspective Tour With Jess Dobkin",
   },
 }
@@ -361,6 +371,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
       "ZQgiFxYAACcAYG_6",
     ],
     "series": [],
+    "times": {
+      "startDateTime": [
+        2023-11-23T16:00:00.000Z,
+      ],
+    },
     "title": "Lights Up on The Cult of Beauty",
   },
 }
@@ -482,6 +497,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
       "ZRrnCxIAACAAASwU",
     ],
     "series": [],
+    "times": {
+      "startDateTime": [
+        2023-11-18T14:00:00.000Z,
+      ],
+    },
     "title": "Standards, My Right to Beauty",
   },
 }
@@ -605,6 +625,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "title": "Exploring Research",
       },
     ],
+    "times": {
+      "startDateTime": [
+        2023-11-14T15:00:00.000Z,
+      ],
+    },
     "title": "Recipes for Early Modern Beauty",
   },
 }
@@ -714,6 +739,11 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
       "ZVIKWBIAACcAZMlz",
     ],
     "series": [],
+    "times": {
+      "startDateTime": [
+        2023-11-22T11:00:00.000Z,
+      ],
+    },
     "title": "Sexing Up the Internet",
   },
 }


### PR DESCRIPTION
## What does this change?

- Adds the additional queries to the events mapping index, as well as ensuring dynamic is set to strict.
- `times: {startDateTime: Date[]` type added to ElasticsearchEventDocument
- The times property then added to the transformEventDocument in the eventDocument. 

## How to test

`events?sort=times.startDateTime&sortOrder=desc` and `events?sort=times.startDateTime&sortOrder=asc` should now display events in order accordingly.

