### PR TITLE
Very basic query for events

### DIFF
--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -8,6 +8,8 @@ import { HttpError } from "./error";
 import { ResultList } from "../types/responses";
 import { resultListResponse } from "../helpers/responses";
 import { queryValidator } from "./validation";
+import { ifDefined } from "../helpers";
+import { eventsQuery } from "../queries/events";
 
 type QueryParams = {
   query?: string;
@@ -49,6 +51,11 @@ const eventsController = (clients: Clients, config: Config): EventsHandler => {
       const searchResponse = await clients.elastic.search<Displayable>({
         index,
         _source: ["display"],
+        query: {
+          bool: {
+            must: ifDefined(queryString, eventsQuery),
+          },
+        },
         sort: [
           { [sortKey]: { order: sortOrder } },
           // Use recency as a "tie-breaker" sort

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -1,0 +1,11 @@
+import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
+
+export const eventsQuery = (queryString: string): QueryDslQueryContainer => ({
+  multi_match: {
+    query: queryString,
+    fields: ["id", "query.title.*^100", "query.caption.*^10"],
+    operator: "or",
+    type: "cross_fields",
+    minimum_should_match: "-25%",
+  },
+});


### PR DESCRIPTION
## What does this change?

Allows for query strings to be passed in and return some more valuable results, mostly based on the `id` and the `title`, but a little bit on the `caption` as well (I went for what level we went for `standfirst` in articles (`^10`). This is just to _have_ something and the metrics could be revisited.

## How to test

```
cd api
yarn install & yarn dev
```
go to `localhost:3000/events?query=[string of your choice]`

## How can we measure success?

Do the results look slightly relevant? Are they returning something different than the default set of results?

## Have we considered potential risks?

I can't really think of any as this is very much a work in progress and shouldn't affect anything else.