### PR TITLE
Add naive healthcheck endpoint for content-api

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -9,6 +9,8 @@ const environmentSchema = z.object({
 });
 const environment = environmentSchema.parse(process.env);
 
+// This configuration is exposed via the public healthcheck endpoint,
+// so be careful not to expose any secrets here.
 const config = {
   pipelineDate: "2023-03-24",
   articlesIndex: "articles",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -7,6 +7,7 @@ import {
   articleController,
   eventController,
   eventsController,
+  healthcheckController,
 } from "./controllers";
 import { Config } from "../config";
 import { Clients } from "./types";
@@ -20,6 +21,7 @@ const createApp = (clients: Clients, config: Config) => {
   app.get("/articles/:id", articleController(clients, config));
   app.get("/events", eventsController(clients, config));
   app.get("/events/:id", eventController(clients, config));
+  app.get("/management/healthcheck", healthcheckController(config));
 
   app.use(errorHandler);
 

--- a/api/src/controllers/healthcheck.ts
+++ b/api/src/controllers/healthcheck.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from "express";
+import asyncHandler from "express-async-handler";
+import { Config } from "../../config";
+
+type PathParams = { id: string };
+
+const healthcheckController = (config: Config): RequestHandler<PathParams> => {
+  return asyncHandler(async (req, res) => {
+    res.status(200).json({
+      status: "ok",
+      config,
+    });
+  });
+};
+
+export default healthcheckController;

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -2,6 +2,7 @@ import articlesController from "./articles";
 import articleController from "./article";
 import eventController from "./event";
 import eventsController from "./events";
+import healthcheckController from "./healthcheck";
 
 export { errorHandler } from "./error";
 export {
@@ -9,4 +10,5 @@ export {
   articleController,
   eventController,
   eventsController,
+  healthcheckController,
 };

--- a/infrastructure/api_stack/api_service.tf
+++ b/infrastructure/api_stack/api_service.tf
@@ -54,7 +54,9 @@ resource "aws_lb_target_group" "content_api" {
   deregistration_delay = 90
 
   health_check {
-    protocol = "TCP"
+      protocol = "HTTP"
+      path     = var.healthcheck_path
+      matcher  = "200"
   }
 
   lifecycle {

--- a/infrastructure/api_stack/api_service.tf
+++ b/infrastructure/api_stack/api_service.tf
@@ -54,9 +54,9 @@ resource "aws_lb_target_group" "content_api" {
   deregistration_delay = 90
 
   health_check {
-      protocol = "HTTP"
-      path     = var.healthcheck_path
-      matcher  = "200"
+    protocol = "HTTP"
+    path     = var.healthcheck_path
+    matcher  = "200"
   }
 
   lifecycle {

--- a/infrastructure/api_stack/variables.tf
+++ b/infrastructure/api_stack/variables.tf
@@ -26,6 +26,11 @@ variable "external_hostname" {
   type = string
 }
 
+variable "healthcheck_path" {
+  type    = string
+  default = "/management/healthcheck"
+}
+
 variable "network_config" {
   type = object({
     vpc_id                           = string


### PR DESCRIPTION
## What does this change?

This change adds a [HTTP healthcheck for a services target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html). The reason for this change is to avoid downtime during deploys, as at present the TCP healthcheck will only wait for nginx to be able to open a connection although the underlying service may not yet have started.

> [!NOTE]
> The healthcheck endpoint does not detect if the elasticsearch client is able to successfully make connections, so does not fully report service health, we should add this in a future PR.

A request to `/management/healthcheck` should result in a HTTP 200 response with the body:

```json
{
    "status": "ok",
    "config": {
        "pipelineDate": "2023-03-24",
        "articlesIndex": "articles",
        "eventsIndex": "events",
        "publicRootUrl": "https://api.wellcomecollection.org/content/v0"
    }
}
````

The `/management/healthcheck`  path was chosen to be in line with other services that do currently provide healthcheck endpoints, and config is surfaced in order to add a little further utility to this endpoint so it can be used to check the setup quickly.

This change requires a `./run_terraform.sh apply` from the infrastructure directory:

```console
Terraform will perform the following actions:

  # module.content_api_prod.aws_lb_target_group.content_api will be updated in-place
  ~ resource "aws_lb_target_group" "content_api" {
        id                                 = "arn:aws:elasticloadbalancing:eu-west-1:756629837203:targetgroup/content-api-prod/59790434c8023181"
        name                               = "content-api-prod"
        tags                               = {}
        # (15 unchanged attributes hidden)

      ~ health_check {
          + matcher             = "200"
          + path                = "/management/healthcheck"
          ~ protocol            = "TCP" -> "HTTP"
            # (6 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.content_api_stage.aws_lb_target_group.content_api will be updated in-place
  ~ resource "aws_lb_target_group" "content_api" {
        id                                 = "arn:aws:elasticloadbalancing:eu-west-1:756629837203:targetgroup/content-api-stage/c38a4e6ae4625348"
        name                               = "content-api-stage"
        tags                               = {}
        # (15 unchanged attributes hidden)

      ~ health_check {
          + matcher             = "200"
          + path                = "/management/healthcheck"
          ~ protocol            = "TCP" -> "HTTP"
            # (6 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # module.pipeline.aws_scheduler_schedule.windows will be updated in-place
  ~ resource "aws_scheduler_schedule" "windows" {
        id                           = "default/content-pipeline-windows-2023-03-24"
        name                         = "content-pipeline-windows-2023-03-24"
        # (5 unchanged attributes hidden)

      ~ target {
          ~ input    = jsonencode(
              ~ {
                  - contentType = "all"
                    # (2 unchanged attributes hidden)
                }
            )
            # (2 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```

## How to test

- [x] Run locally, can you reach the healthcheck endpoint?
- [ ] Deploy to the staging environment, test whether the healthchecks are respected.

## How can we measure success?

No false alarms during deployment, the healthcheck properly reports the state of the service.

## Have we considered potential risks?

Changing the health-checks changes the failure modes for the API, we should test thoroughly in stage before deploying to prod, consider and document the impact of extending the health check to fail in other situations (e.g. elasticsearch is unavailable).
