### PR TITLE
add audiences and series to display object

### DIFF
--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -17,7 +17,7 @@ import {
   asTitle,
   isNotUndefined,
 } from "../helpers/type-guards";
-import { linkedDocumentIdentifiers, formatSeriesForQuery } from "./utils";
+import { linkedDocumentIdentifiers, transformSeries } from "./utils";
 
 const getContributors = (
   document: prismic.PrismicDocument<WithContributors>
@@ -142,7 +142,7 @@ export const transformArticle = (
       caption,
       body: queryBody,
       standfirst: queryStandfirst,
-      series: formatSeriesForQuery(document),
+      series: transformSeries(document),
     },
     filter: {
       contributorIds: flatContributors.map((c) => c.id),

--- a/pipeline/src/transformers/utils.ts
+++ b/pipeline/src/transformers/utils.ts
@@ -5,7 +5,7 @@ import {
   isNotUndefined,
 } from "../helpers/type-guards";
 import { WithSeries } from "../types/prismic/series";
-import { QuerySeries } from "../types/transformed";
+import { Series } from "../types/transformed";
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
@@ -56,9 +56,9 @@ export const linkedDocumentIdentifiers = (rootDocument: any): string[] => {
   return Array.from(getLinkedIdentifiers(rootDocument, new Set<string>()));
 };
 
-export const formatSeriesForQuery = (
+export const transformSeries = (
   document: PrismicDocument<WithSeries>
-): QuerySeries => {
+): Series => {
   return document.data.series.flatMap(({ series }) =>
     isFilledLinkToDocumentWithData(series)
       ? {

--- a/pipeline/src/types/prismic/eventDocuments.ts
+++ b/pipeline/src/types/prismic/eventDocuments.ts
@@ -31,6 +31,16 @@ export type WithInterpretations = {
   }>;
 };
 
+export type WithAudiences = {
+  audiences: prismic.GroupField<{
+    audience: prismic.ContentRelationshipField<
+      "audience",
+      "en-gb",
+      { title: prismic.RichTextField }
+    >;
+  }>;
+};
+
 export type EventPrismicDocument = prismic.PrismicDocument<
   {
     times: prismic.GroupField<{
@@ -41,6 +51,7 @@ export type EventPrismicDocument = prismic.PrismicDocument<
     WithLocations &
     WithInterpretations &
     WithSeries &
+    WithAudiences &
     CommonPrismicFields,
   "events"
 >;

--- a/pipeline/src/types/transformed/eventDocument.ts
+++ b/pipeline/src/types/transformed/eventDocument.ts
@@ -1,4 +1,5 @@
 import { Image } from ".";
+import { Series } from ".";
 
 export type EventDocument = {
   type: "Event";
@@ -9,6 +10,8 @@ export type EventDocument = {
   format: EventDocumentFormat;
   locations: EventDocumentLocation[];
   interpretations: EventDocumentInterpretation[];
+  audiences: EventDocumentAudience[];
+  series: Series;
 };
 
 export type EventDocumentFormat = {
@@ -25,6 +28,12 @@ export type EventDocumentLocation = {
 
 export type EventDocumentInterpretation = {
   type: "EventInterpretation";
+  id: string;
+  label?: string;
+};
+
+export type EventDocumentAudience = {
+  type: "EventAudience";
   id: string;
   label?: string;
 };

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -1,4 +1,3 @@
-import { TimestampField } from "@prismicio/client/*";
 import { PrismicImage } from "../prismic";
 import { Article, ArticleFormat } from "../transformed/article";
 import {
@@ -29,7 +28,7 @@ export type Contributor = {
   };
 };
 
-export type QuerySeries = Array<{
+export type Series = Array<{
   id: string;
   title?: string;
   contributors?: string[];
@@ -55,7 +54,7 @@ export type ElasticsearchArticle = {
     caption?: string;
     body?: string[] | string;
     standfirst?: string;
-    series: QuerySeries;
+    series: Series;
   };
   filter: {
     publicationDate: Date;
@@ -75,7 +74,7 @@ export type ElasticsearchEventDocument = {
     linkedIdentifiers: string[];
     title: string;
     caption?: string;
-    series: QuerySeries;
+    series: Series;
     times: { startDateTime: Date[] };
   };
 };

--- a/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZFt0WhQAAHnPEH7P) 1`] = `
 {
   "display": {
+    "audiences": [],
     "format": {
       "id": "W5fV5iYAACQAMxHb",
       "label": "Festival",
@@ -91,6 +92,16 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [
+      {
+        "contributors": [
+          "Land Body Ecologies",
+          "The Hub",
+        ],
+        "id": "ZFt3UBQAAMFmEIya",
+        "title": "Land Body Ecologies Festival",
+      },
+    ],
     "times": [
       {
         "endDateTime": 2023-06-23T17:00:00.000Z,
@@ -147,6 +158,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZJLZoRAAACIARz42) 1`] = `
 {
   "display": {
+    "audiences": [],
     "format": {
       "id": "WmYRpCQAACUAn-Ap",
       "label": "Gallery tour",
@@ -232,6 +244,13 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [
+      {
+        "contributors": [],
+        "id": "WlYUDCQAACQAWcdt",
+        "title": "Perspective Tours",
+      },
+    ],
     "times": [
       {
         "endDateTime": 2023-08-24T17:30:00.000Z,
@@ -272,6 +291,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZQgdkREAAAbr6cRR) 1`] = `
 {
   "display": {
+    "audiences": [],
     "format": {
       "id": "dfc2b7f9-c362-47da-9644-b0f98212ccaa",
       "label": "Event",
@@ -351,6 +371,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [],
     "times": [
       {
         "endDateTime": 2023-12-16T14:00:00.000Z,
@@ -384,6 +405,13 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZRrijRIAAJNSARgG) 1`] = `
 {
   "display": {
+    "audiences": [
+      {
+        "id": "WlYWECQAACcAWdBf",
+        "label": "Youth event",
+        "type": "EventAudience",
+      },
+    ],
     "format": {
       "id": "Wn3Q3SoAACsAIeFI",
       "label": "Performance",
@@ -474,6 +502,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [],
     "times": [
       {
         "endDateTime": 2023-11-18T16:00:00.000Z,
@@ -510,6 +539,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZSPXJBAAACIAiERm) 1`] = `
 {
   "display": {
+    "audiences": [],
     "format": {
       "id": "Wd-QYCcAACcAoiJS",
       "label": "Discussion",
@@ -595,6 +625,13 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [
+      {
+        "contributors": [],
+        "id": "W5Zj_CYAACQALK5B",
+        "title": "Exploring Research",
+      },
+    ],
     "times": [
       {
         "endDateTime": 2023-11-14T16:30:00.000Z,
@@ -638,6 +675,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
 exports[`eventDocument transformer transforms articles from Prismic to the expected format (document: events/ZTevFxAAACQAyHEk) 1`] = `
 {
   "display": {
+    "audiences": [],
     "format": {
       "id": "WcKmiysAACx_A8NR",
       "label": "Workshop",
@@ -717,6 +755,7 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
         "type": "EventLocation",
       },
     ],
+    "series": [],
     "times": [
       {
         "endDateTime": 2023-11-22T14:00:00.000Z,


### PR DESCRIPTION
## What does this change?
https://github.com/wellcomecollection/content-api/issues/92
Following Raph's work on https://github.com/wellcomecollection/wellcomecollection.org/issues/10587 it came up that some properties are missing in the `display` part of the eventDocuments. This PR adds them in
`audiences` is in this format
```
{
  type: "EventAudience",
  id: PrismicId, // string
  label: title, // string
}
``` 
`series` like so
```
{
    "contributors": [
      "Land Body Ecologies",
      "The Hub",
    ],
    "id": "ZFt3UBQAAMFmEIya",
    "title": "Land Body Ecologies Festival",
 },
```

## How to test

Reindex has not been performed yet. Once this is approved we'll reindex and will be able to check that the documents look as expected. The event stuff is behind a toggle but the API is up, can be used for testing as well
Snapshots have been updated and look as expected 

## How can we measure success?

Event cards in search results can be rendered with all the required data

## Have we considered potential risks?

Events are not live yet so no risk to consider

NOTE: 
- ~the `relaxed` bit need more discussion/confirmation by editorial and has been left out~ Editorial confirmed they're retiring `isRelaxedPerformance` sat at the root level in favour of `relaxed` being an `InterpretationType`. We already have `interpretations` in the display
- ~`isFullyBooked` does not appear on the What's On event card so left out as well for consistency. It appears that Prismic is not aware of the booking/availability status of EventBrite events anyway~ <- it's not clear how `isFullyBooked` and `onlineIsFullyBooked` are set. Will discuss with Editorial and get back to it
