### PR TITLE
Add default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These are default codeowners, later rules take precedence
+*	@wellcomecollection/js-ts-reviewers


### PR DESCRIPTION
## What does this change?

I've added a default code owner so they automatically get added to PRs as reviewers. Let me know if it should be a different Team, but it makes sense to me as this repo is TS.

## How to test

I guess once it's in, and a PR gets created we could check it adds it automatically to reviewers?

## How can we measure success?

Are PRs not going unnoticed anymore 👀 

## Have we considered potential risks?

I don't think there is any.
