### PR TITLE
add booking info in times objects + childScheduledEvent at root level

### DIFF
--- a/pipeline/src/graph-queries/eventDocuments.ts
+++ b/pipeline/src/graph-queries/eventDocuments.ts
@@ -29,6 +29,8 @@ const query = `{
     times {
       startDateTime
       endDateTime
+      isFullyBooked
+      onlineIsFullyBooked
     }
     audiences {
       audience {

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -144,7 +144,7 @@ export const transformEventDocument = (
 
   return {
     id,
-    ...(tags.includes("delist") && { childScheduledEvent: true }),
+    ...(tags.includes("delist") && { isChildScheduledEvent: true }),
     display: {
       type: "Event",
       id,

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -97,13 +97,23 @@ const transformAudiences = (document: PrismicDocument<WithAudiences>) => {
     .filter(isNotUndefined);
 };
 
-const prismicTimestampToDate = (times: {
+const transformTimes = (times: {
   startDateTime: TimestampField;
   endDateTime: TimestampField;
-}): { startDateTime: Date | undefined; endDateTime: Date | undefined } => {
+  isFullyBooked: "yes" | null;
+  onlineIsFullyBooked: "yes" | null;
+}): {
+  startDateTime: Date | undefined;
+  endDateTime: Date | undefined;
+  isFullyBooked: { inVenue: boolean; online: boolean };
+} => {
   return {
     startDateTime: asDate(times.startDateTime) || undefined,
     endDateTime: asDate(times.endDateTime) || undefined,
+    isFullyBooked: {
+      inVenue: !!times.isFullyBooked,
+      online: !!times.onlineIsFullyBooked,
+    },
   };
 };
 
@@ -113,9 +123,10 @@ export const transformEventDocument = (
   const {
     data: { title, promo, times },
     id,
+    tags,
   } = document;
 
-  const documentTimes = times.map(prismicTimestampToDate);
+  const documentTimes = times.map(transformTimes);
 
   const primaryImage = promo?.[0]?.primary;
   const image =
@@ -133,12 +144,13 @@ export const transformEventDocument = (
 
   return {
     id,
+    ...(tags.includes("delist") && { childScheduledEvent: true }),
     display: {
       type: "Event",
       id,
       title: asTitle(title),
       image,
-      times: times.map(prismicTimestampToDate),
+      times: times.map(transformTimes),
       format,
       locations,
       interpretations,

--- a/pipeline/src/types/prismic/eventDocuments.ts
+++ b/pipeline/src/types/prismic/eventDocuments.ts
@@ -46,6 +46,8 @@ export type EventPrismicDocument = prismic.PrismicDocument<
     times: prismic.GroupField<{
       startDateTime: prismic.TimestampField;
       endDateTime: prismic.TimestampField;
+      isFullyBooked: "yes" | null;
+      onlineIsFullyBooked: "yes" | null;
     }>;
   } & WithEventFormat &
     WithLocations &

--- a/pipeline/src/types/transformed/eventDocument.ts
+++ b/pipeline/src/types/transformed/eventDocument.ts
@@ -6,7 +6,11 @@ export type EventDocument = {
   id: string;
   title: string;
   image?: Image;
-  times: { startDateTime?: Date; endDateTime?: Date }[];
+  times: {
+    startDateTime?: Date;
+    endDateTime?: Date;
+    isFullyBooked: { inVenue: boolean; online: boolean };
+  }[];
   format: EventDocumentFormat;
   locations: EventDocumentLocation[];
   interpretations: EventDocumentInterpretation[];

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -69,7 +69,7 @@ export type ElasticsearchArticle = {
 
 export type ElasticsearchEventDocument = {
   id: string;
-  childScheduledEvent?: boolean;
+  isChildScheduledEvent?: boolean;
   display: EventDocument;
   query: {
     linkedIdentifiers: string[];

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -69,6 +69,7 @@ export type ElasticsearchArticle = {
 
 export type ElasticsearchEventDocument = {
   id: string;
+  childScheduledEvent?: boolean;
   display: EventDocument;
   query: {
     linkedIdentifiers: string[];

--- a/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
@@ -105,6 +105,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-06-23T17:00:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-06-23T09:00:00.000Z,
       },
     ],
@@ -254,6 +258,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-08-24T17:30:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-08-24T16:30:00.000Z,
       },
     ],
@@ -375,6 +383,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-12-16T14:00:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-11-23T16:00:00.000Z,
       },
     ],
@@ -506,6 +518,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-11-18T16:00:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-11-18T14:00:00.000Z,
       },
     ],
@@ -635,6 +651,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-11-14T16:30:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-11-14T15:00:00.000Z,
       },
     ],
@@ -759,6 +779,10 @@ exports[`eventDocument transformer transforms articles from Prismic to the expec
     "times": [
       {
         "endDateTime": 2023-11-22T14:00:00.000Z,
+        "isFullyBooked": {
+          "inVenue": false,
+          "online": false,
+        },
         "startDateTime": 2023-11-22T11:00:00.000Z,
       },
     ],


### PR DESCRIPTION
## What does this change?

As discussed, we're adding a property to indicate an event is a "child", ie. part of the schedule of a "parent" event, to be excluded from search results as the MVP stage https://github.com/wellcomecollection/content-api/issues/93
Also adding online/in-venue booking status/availability https://github.com/wellcomecollection/content-api/issues/96

## How to test

See updated test snapshots 

## How can we measure success?

Once the changes are reflected in the index, FE will be able to display booking status on the event card in search
We can also exclude delisted events (without pictures) from search 

## Have we considered potential risks?

Feature behind a toggle so no risk

