### PR TITLE
add filter/aggs to events endpoint

### DIFF
--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -18,8 +18,6 @@ import { pickFiltersFromQuery } from "../helpers/requests";
 import { esQuery } from "../queries/common";
 import { rewriteAggregationsForFacets } from "../queries/faceting";
 
-const util = require("util");
-
 type QueryParams = {
   query?: string;
   sort?: string;
@@ -88,7 +86,9 @@ const eventsController = (clients: Clients, config: Config): EventsHandler => {
             must: ifDefined(queryString, eventsQuery),
             must_not: {
               term: {
-                isChildScheduledEvent: true, // exclude childScheduledEvents from search
+                // exclude childScheduledEvents from search
+                // https://github.com/wellcomecollection/content-api/issues/93
+                isChildScheduledEvent: true,
               },
             },
           },

--- a/api/src/helpers/requests.ts
+++ b/api/src/helpers/requests.ts
@@ -1,5 +1,4 @@
 import { StringLiteral } from "../types";
-import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
 import { ifDefined } from "./index";
 import { Filter } from "../queries/common";
 

--- a/api/src/helpers/responses.ts
+++ b/api/src/helpers/responses.ts
@@ -4,10 +4,8 @@ import {
   AggregationsStringTermsBucket,
   SearchResponse,
 } from "@elastic/elasticsearch/lib/api/types";
-import logger from "@weco/content-common/services/logging";
 import { Displayable } from "../types";
 import {
-  Aggregation,
   AggregationBucket,
   Aggregations,
   ResultList,

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -1,4 +1,5 @@
 import { QueryDslQueryContainer } from "@elastic/elasticsearch/lib/api/types";
+import { TermsFilter } from "./common";
 
 export const eventsQuery = (queryString: string): QueryDslQueryContainer => ({
   multi_match: {
@@ -9,3 +10,62 @@ export const eventsQuery = (queryString: string): QueryDslQueryContainer => ({
     minimum_should_match: "-25%",
   },
 });
+
+export const eventsFilter = {
+  format: (formats: string[]): TermsFilter => ({
+    values: formats,
+    esQuery: {
+      terms: {
+        "filter.formatId": formats,
+      },
+    },
+  }),
+  interpretation: (interpretations: string[]): TermsFilter => ({
+    values: interpretations,
+    esQuery: {
+      terms: {
+        "filter.interpretationIds": interpretations,
+      },
+    },
+  }),
+  audience: (audiences: string[]): TermsFilter => ({
+    values: audiences,
+    esQuery: {
+      terms: {
+        "filter.audienceIds": audiences,
+      },
+    },
+  }),
+  isOnline: (): QueryDslQueryContainer => ({
+    term: {
+      "filter.isOnline": true,
+    },
+  }),
+};
+
+export const eventsAggregations = {
+  format: {
+    terms: {
+      size: 20,
+      field: "aggregatableValues.format",
+    },
+  },
+  interpretation: {
+    terms: {
+      size: 20,
+      field: "aggregatableValues.interpretations",
+    },
+  },
+  audience: {
+    terms: {
+      size: 10,
+      field: "aggregatableValues.audiences",
+    },
+  },
+  isOnline: {
+    terms: {
+      size: 2,
+      field: "aggregatableValues.location",
+    },
+  },
+} as const;

--- a/api/src/queries/faceting.ts
+++ b/api/src/queries/faceting.ts
@@ -1,7 +1,4 @@
-import {
-  AggregationsAggregationContainer,
-  QueryDslQueryContainer,
-} from "@elastic/elasticsearch/lib/api/types";
+import { AggregationsAggregationContainer } from "@elastic/elasticsearch/lib/api/types";
 import { esQuery, Filter, isTermsFilter } from "./common";
 
 // This file contains functions to rewrite terms aggregations and filters

--- a/api/test/__snapshots__/query.test.ts.snap
+++ b/api/test/__snapshots__/query.test.ts.snap
@@ -92,7 +92,7 @@ exports[`articles query makes the expected query to ES for a given set of query 
     },
   },
   "from": 336,
-  "index": "test",
+  "index": "test-articles",
   "post_filter": {
     "bool": {
       "filter": [
@@ -157,6 +157,157 @@ exports[`articles query makes the expected query to ES for a given set of query 
     },
     {
       "query.publicationDate": {
+        "order": "desc",
+      },
+    },
+  ],
+}
+`;
+
+exports[`events query makes the expected query to ES for a given set of query parameters 1`] = `
+{
+  "_source": [
+    "display",
+  ],
+  "aggregations": {
+    "format": {
+      "aggs": {
+        "self_filter": {
+          "aggs": {
+            "terms": {
+              "terms": {
+                "field": "aggregatableValues.format",
+                "include": ".*test-format.*",
+                "min_doc_count": 0,
+                "size": 20,
+              },
+            },
+          },
+          "filter": {
+            "terms": {
+              "filter.formatId": [
+                "test-format",
+              ],
+            },
+          },
+        },
+        "terms": {
+          "terms": {
+            "field": "aggregatableValues.format",
+            "size": 20,
+          },
+        },
+      },
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "terms": {
+                "filter.interpretationIds": [
+                  "test-interpretation",
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+    "interpretation": {
+      "aggs": {
+        "self_filter": {
+          "aggs": {
+            "terms": {
+              "terms": {
+                "field": "aggregatableValues.interpretations",
+                "include": ".*test-interpretation.*",
+                "min_doc_count": 0,
+                "size": 20,
+              },
+            },
+          },
+          "filter": {
+            "terms": {
+              "filter.interpretationIds": [
+                "test-interpretation",
+              ],
+            },
+          },
+        },
+        "terms": {
+          "terms": {
+            "field": "aggregatableValues.interpretations",
+            "size": 20,
+          },
+        },
+      },
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "terms": {
+                "filter.formatId": [
+                  "test-format",
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+  "from": 120,
+  "index": "test-events",
+  "post_filter": {
+    "bool": {
+      "filter": [
+        {
+          "terms": {
+            "filter.formatId": [
+              "test-format",
+            ],
+          },
+        },
+        {
+          "terms": {
+            "filter.interpretationIds": [
+              "test-interpretation",
+            ],
+          },
+        },
+      ],
+    },
+  },
+  "query": {
+    "bool": {
+      "must": {
+        "multi_match": {
+          "fields": [
+            "id",
+            "query.title.*^100",
+            "query.caption.*^10",
+          ],
+          "minimum_should_match": "-25%",
+          "operator": "or",
+          "query": "henry wellcome",
+          "type": "cross_fields",
+        },
+      },
+      "must_not": {
+        "term": {
+          "isChildScheduledEvent": true,
+        },
+      },
+    },
+  },
+  "size": 20,
+  "sort": [
+    {
+      "_score": {
+        "order": "asc",
+      },
+    },
+    {
+      "query.times.startDateTime": {
         "order": "desc",
       },
     },


### PR DESCRIPTION
## What does this change?
https://github.com/wellcomecollection/content-api/issues/71
Adds filters and aggregations to `/events` search endpoint 

## How to test

Stage
`https://api-stage.wellcomecollection.org/content/v0/events?aggregations=format%2Caudience%2CisOnline%2Cinterpretation`

Filtered by interpretation=Auto-captioned and format=Discussion
`https://api-stage.wellcomecollection.org/content/v0/events?aggregations=format%2Caudience%2CisOnline%2Cinterpretation&interpretation=X2jPiRMAACIA8Vzo&format=Wd-QYCcAACcAoiJS&pageSize=1` 

## How can we measure success?
Ability to filter event searches

## Have we considered potential risks?

Still behind a toggle 

