### PR TITLE
Make null equal false for isAvailableOnline

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -33,3 +33,10 @@ Our solution is to:
 1. Store all of the `linkedIdentifiers` of a parent document alongside it in the index. For example, this would be the identifiers of the contributors for a given article.
 2. When _any_ document is updated, we query for anything that includes its identifier in those `linkedIdentifiers`.
 3. If we find anything, we re-fetch that document too (we don't worry about applying the update we've received to already-indexed documents, we just fetch them again).
+
+## How to reindex
+
+First, ensure it's safe to do so as it will affect data used in production. Then you'll need to be logged in and specify the role in the command line.
+
+For example:
+`AWS_PROFILE=catalogue-developer yarn reindex-events`

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -142,6 +142,10 @@ export const transformEventDocument = (
 
   const audiences = transformAudiences(document);
 
+  // Events that existed before the field was added have `null` as a value
+  // They should be considered as false
+  const isAvailableOnline = !!availableOnline;
+
   return {
     id,
     ...(tags.includes("delist") && { isChildScheduledEvent: true }),
@@ -156,7 +160,7 @@ export const transformEventDocument = (
       interpretations,
       audiences,
       series: transformSeries(document),
-      isAvailableOnline: availableOnline,
+      isAvailableOnline,
     },
     query: {
       linkedIdentifiers: linkedDocumentIdentifiers(document),
@@ -174,7 +178,7 @@ export const transformEventDocument = (
       isOnline: !!isOnline,
       interpretationIds: interpretations.map((i) => i.id),
       audienceIds: audiences.map((a) => a.id),
-      isAvailableOnline: availableOnline,
+      isAvailableOnline,
     },
     aggregatableValues: {
       format: JSON.stringify(format),
@@ -185,7 +189,7 @@ export const transformEventDocument = (
         isOnline: !!isOnline,
       }),
       isAvailableOnline: JSON.stringify({
-        isAvailableOnline: availableOnline,
+        isAvailableOnline,
       }),
     },
   };


### PR DESCRIPTION
## What does this change?

`isAvailableOnline: null` is now transformed to `isAvailableOnline: false`.
I've also added info to the README on how to run reindexes.

## How to test

Have a look on ES or run locally to find formerly `null` values being `false`

## How can we measure success?

Relevant results are found and people are happy

## Have we considered potential risks?

It's all behind a toggle so pretty safe and can easily be reverted.


---


Reindex was run