### PR TITLE
Add isAvailableOnline to API and validate its value

### DIFF
--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -41,6 +41,13 @@ export const eventsFilter = {
       "filter.isOnline": true,
     },
   }),
+  isAvailableOnline: (): QueryDslQueryContainer => {
+    return {
+      term: {
+        "filter.isAvailableOnline": true,
+      },
+    };
+  },
 };
 
 export const eventsAggregations = {
@@ -66,6 +73,12 @@ export const eventsAggregations = {
     terms: {
       size: 2,
       field: "aggregatableValues.location",
+    },
+  },
+  isAvailableOnline: {
+    terms: {
+      size: 2,
+      field: "aggregatableValues.isAvailableOnline",
     },
   },
 } as const;


### PR DESCRIPTION
## What does this change?

- Adds `isAvailableOnline` as a valid boolean param
- Adds a paramsValidator function, currently only checks `isAvailableOnline` so open to simplifying but thought it made things more readable

## How to test

Run locally and try an array of queries, such as
`http://localhost:3000/events?format=Wd-QYCcAACcAoiJS`, (should return 163 results)
`http://localhost:3000/events?format=Wd-QYCcAACcAoiJS&isAvailableOnline=true`, (should return 50 results)
`http://localhost:3000/events?format=Wd-QYCcAACcAoiJS&isAvailableOnline=test`, (should return a Bad Request)
`http://localhost:3000/events?format=Wd-QYCcAACcAoiJS&isAvailableOnline=true,test` (should return a Bad Request)

## How can we measure success?

Users are finding it useful and it's in use.

## Have we considered potential risks?

Behind a toggle and easy to revert, so no risks per say
