### PR TITLE
model prismic and transformed venue opening times

### DIFF
--- a/pipeline/src/types/prismic/venue.ts
+++ b/pipeline/src/types/prismic/venue.ts
@@ -1,0 +1,23 @@
+import * as prismic from "@prismicio/client";
+
+type RegularOpeningDay = prismic.GroupField<{
+  startDateTime: prismic.TimestampField | null;
+  endDateTime: prismic.TimestampField | null;
+}>;
+
+export type VenuePrismicDocument = prismic.PrismicDocument<{
+  title: string;
+  monday: RegularOpeningDay;
+  tuesday: RegularOpeningDay;
+  wednesday: RegularOpeningDay;
+  thursday: RegularOpeningDay;
+  friday: RegularOpeningDay;
+  saturday: RegularOpeningDay;
+  sunday: RegularOpeningDay;
+  modifiedDayOpeningTimes: prismic.GroupField<{
+    overrideDate: prismic.TimestampField;
+    type: string | null;
+    startDateTime: prismic.TimestampField | null;
+    endDateTime: prismic.TimestampField | null;
+  }>;
+}>;

--- a/pipeline/src/types/transformed/venue.ts
+++ b/pipeline/src/types/transformed/venue.ts
@@ -1,0 +1,26 @@
+export type Venue = {
+  type: "Venue";
+  id: string;
+  title: string;
+  regularOpeningDays: {
+    dayOfWeek: DayOfWeek;
+    opens: string;
+    closes: string;
+    isClosed?: boolean;
+  }[];
+  exceptionalOpeningDays: {
+    overrideDate: Date;
+    opens: string;
+    closes: string;
+    isClosed?: boolean;
+  }[];
+};
+
+type DayOfWeek =
+  | "monday"
+  | "tuesday"
+  | "wesdnesday"
+  | "thursday"
+  | "friday"
+  | "saturday"
+  | "sunday";

--- a/pipeline/src/types/transformed/venue.ts
+++ b/pipeline/src/types/transformed/venue.ts
@@ -19,7 +19,7 @@ export type Venue = {
 type DayOfWeek =
   | "monday"
   | "tuesday"
-  | "wesdnesday"
+  | "wednesday"
   | "thursday"
   | "friday"
   | "saturday"


### PR DESCRIPTION
In the Prismic type `modifiedDayOpeningTimes.type` is not necessary now that I think of it 

In the transformed type `id` could be the Prismic document id or we can created our own

We might also add a simple graph query if we don't want to rely on the hardcoded Prismic document id for library venue 
