### PR TITLE
make isAvailableOnline agg bucket more like the others, ie type+label

### DIFF
--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -189,7 +189,9 @@ export const transformEventDocument = (
         isOnline: !!isOnline,
       }),
       isAvailableOnline: JSON.stringify({
-        isAvailableOnline,
+        type: "OnlineAvailabilityBoolean",
+        value: isAvailableOnline,
+        label: "Catch-up event",
       }),
     },
   };

--- a/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
@@ -6,7 +6,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
     "audiences": [],
     "format": "{"type":"EventFormat","id":"W5fV5iYAACQAMxHb","label":"Festival"}",
     "interpretations": [],
-    "isAvailableOnline": "{"isAvailableOnline":false}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":false,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":true}",
   },
   "display": {
@@ -182,7 +182,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
     "interpretations": [
       "{"type":"EventInterpretation","id":"XkFGqxEAACIAIhNH","label":"British Sign Language"}",
     ],
-    "isAvailableOnline": "{"isAvailableOnline":false}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":false,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":false}",
   },
   "display": {
@@ -336,7 +336,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
     "audiences": [],
     "format": "{"type":"EventFormat","id":"dfc2b7f9-c362-47da-9644-b0f98212ccaa","label":"Event"}",
     "interpretations": [],
-    "isAvailableOnline": "{"isAvailableOnline":false}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":false,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":false}",
   },
   "display": {
@@ -484,7 +484,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "{"type":"EventInterpretation","id":"XkFGqxEAACIAIhNH","label":"British Sign Language"}",
       "{"type":"EventInterpretation","id":"W5JXVSYAACYAGtkh","label":"Relaxed"}",
     ],
-    "isAvailableOnline": "{"isAvailableOnline":false}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":false,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":false}",
   },
   "display": {
@@ -644,7 +644,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
     "interpretations": [
       "{"type":"EventInterpretation","id":"YzGD9hEAAEAKfx0E","label":"Captioned (online)"}",
     ],
-    "isAvailableOnline": "{"isAvailableOnline":true}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":true,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":true}",
   },
   "display": {
@@ -801,7 +801,7 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
     "audiences": [],
     "format": "{"type":"EventFormat","id":"WcKmiysAACx_A8NR","label":"Workshop"}",
     "interpretations": [],
-    "isAvailableOnline": "{"isAvailableOnline":false}",
+    "isAvailableOnline": "{"type":"OnlineAvailabilityBoolean","value":false,"label":"Catch-up event"}",
     "location": "{"type":"EventLocation","isOnline":false}",
   },
   "display": {


### PR DESCRIPTION
## What does this change?

Make the boolean isAvailableOnline agg bucket more like the others, with a label and type

## How to test

Run content-api locally
Hit `http://localhost:3000/events?aggregations=isAvailableOnline%2Cformat%2Caudience%2CisOnline%2Cinterpretation`
See that the response contains 
```
"aggregations": {
  ... other aggregations,
  "isAvailableOnline": {
    "buckets": [
      {
        "data": {
          "type": "OnlineAvailabilityBoolean",
          "value": true,
          "label": "Catch-up event"
        },
        "count": 24,
        "type": "AggregationBucket"
      },
      {
        "data": {
          "type": "OnlineAvailabilityBoolean",
          "value": false,
          "label": "Catch-up event"
        },
        "count": 3,
        "type": "AggregationBucket"
      }
    ],
    "type": "Aggregation"
  },
}
```

## How can we measure success?

Raph's types are happier in wc.org

## Have we considered potential risks?

N/A
