### PR TITLE
Remove isOnline and create locations

### DIFF
--- a/pipeline/src/indices/events.ts
+++ b/pipeline/src/indices/events.ts
@@ -98,13 +98,13 @@ export const mappings = {
         formatId: {
           type: "keyword",
         },
-        isOnline: {
-          type: "boolean",
-        },
         interpretationIds: {
           type: "keyword",
         },
         audienceIds: {
+          type: "keyword",
+        },
+        locationIds: {
           type: "keyword",
         },
         isAvailableOnline: {
@@ -123,7 +123,7 @@ export const mappings = {
         audiences: {
           type: "keyword",
         },
-        location: {
+        locations: {
           type: "keyword",
         },
         isAvailableOnline: {

--- a/pipeline/src/types/transformed/eventDocument.ts
+++ b/pipeline/src/types/transformed/eventDocument.ts
@@ -12,7 +12,7 @@ export type EventDocument = {
     isFullyBooked: { inVenue: boolean; online: boolean };
   }[];
   format: EventDocumentFormat;
-  locations: EventDocumentLocation[];
+  locations: EventDocumentLocations;
   interpretations: EventDocumentInterpretation[];
   audiences: EventDocumentAudience[];
   series: Series;
@@ -25,8 +25,26 @@ export type EventDocumentFormat = {
   label?: string;
 };
 
-export type EventDocumentLocation = {
-  type: "EventLocation";
+type OnlineAttendance = {
+  id: "online";
+  label: "Online";
+};
+type BuildingAttendance = {
+  id: "in-our-building";
+  label: "In our building";
+};
+
+export type EventDocumentLocations = {
+  isOnline: boolean;
+  places?: EventDocumentPlace[];
+  attendance: ((BuildingAttendance | OnlineAttendance) & {
+    type: "EventAttendance";
+  })[];
+  type: "EventLocations";
+};
+
+export type EventDocumentPlace = {
+  type: "EventPlace";
   id: string;
   label?: string;
 };

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -3,7 +3,7 @@ import { Article, ArticleFormat } from "../transformed/article";
 import {
   EventDocument,
   EventDocumentFormat,
-  EventDocumentLocation,
+  EventDocumentLocations,
   EventDocumentInterpretation,
 } from "../transformed/eventDocument";
 
@@ -39,7 +39,7 @@ export type { Article, ArticleFormat };
 export type {
   EventDocument,
   EventDocumentFormat,
-  EventDocumentLocation,
+  EventDocumentLocations,
   EventDocumentInterpretation,
 };
 
@@ -80,16 +80,16 @@ export type ElasticsearchEventDocument = {
   };
   filter: {
     formatId: string;
-    isOnline: boolean;
     interpretationIds: string[];
     audienceIds: string[];
+    locationIds: string[];
     isAvailableOnline: boolean;
   };
   aggregatableValues: {
     format: string;
-    location: string;
     interpretations: string[];
     audiences: string[];
+    locations: string[];
     isAvailableOnline: string;
   };
 };


### PR DESCRIPTION
## What does this change?

Removes our original idea of an `isOnline` boolean filter and creates a `locations` object that will serve both the needs of the FE display and the BE filtering/aggregations.

## How to test

Explore ElasticCloud as it's been reindexed just now, view the new objects.

## How can we measure success?

We can happily work on the API and the FE parts without issue

## Have we considered potential risks?

Everything behind a toggle, not risky.

