### PR TITLE
nextOpeningDates start at and include today

### DIFF
--- a/api/src/controllers/utils.ts
+++ b/api/src/controllers/utils.ts
@@ -13,10 +13,7 @@ export function getNextOpeningDates(
   // create a dateList of 21 consecutive days starting tomorrow
   // 21 is arbitrary, we just need to have at least 12 once all the closed days have been removed
   const dateNow = new Date();
-  const timeSeriesStart = addDays(dateNow, 1);
-  const dateList = [...Array(21).keys()].map((day) =>
-    addDays(timeSeriesStart, day)
-  );
+  const dateList = [...Array(21).keys()].map((day) => addDays(dateNow, day));
 
   // day(s) of the week when the venue is normally closed, as ["monday", "sunday", ...]
   const regularClosedDays = regularOpeningDays

--- a/api/test/utils.test.ts
+++ b/api/test/utils.test.ts
@@ -73,12 +73,12 @@ const mockDateNow = (dateToMock: string) => {
 };
 
 describe("getNextOpeningDates", () => {
-  it("start the dateList at today + 1", () => {
+  it("start the dateList from today", () => {
     mockDateNow("2024-03-12T08:00:00.000Z");
 
     const expectedStart = {
-      open: "2024-03-13T10:00:00.000Z",
-      close: "2024-03-13T18:00:00.000Z",
+      open: "2024-03-12T10:00:00.000Z",
+      close: "2024-03-12T18:00:00.000Z",
     };
 
     expect(getNextOpeningDates(regularOpeningDays, [])[0]).toEqual(
@@ -90,6 +90,7 @@ describe("getNextOpeningDates", () => {
     mockDateNow("2024-03-12T10:00:00.000Z");
 
     const expectedNextOpeningDates = [
+      { open: "2024-03-12T10:00:00.000Z", close: "2024-03-12T18:00:00.000Z" },
       { open: "2024-03-13T10:00:00.000Z", close: "2024-03-13T18:00:00.000Z" },
       { open: "2024-03-14T10:00:00.000Z", close: "2024-03-14T20:00:00.000Z" },
       { open: "2024-03-15T10:00:00.000Z", close: "2024-03-15T18:00:00.000Z" },
@@ -107,7 +108,6 @@ describe("getNextOpeningDates", () => {
       { open: "2024-03-29T10:00:00.000Z", close: "2024-03-29T18:00:00.000Z" },
       { open: "2024-03-30T10:00:00.000Z", close: "2024-03-30T16:00:00.000Z" },
       { open: "2024-04-01T09:00:00.000Z", close: "2024-04-01T17:00:00.000Z" },
-      { open: "2024-04-02T09:00:00.000Z", close: "2024-04-02T17:00:00.000Z" },
     ];
 
     expect(getNextOpeningDates(regularOpeningDays, [])).toStrictEqual(
@@ -119,6 +119,7 @@ describe("getNextOpeningDates", () => {
     mockDateNow("2024-03-12T10:00:00.000Z");
 
     const expectedNextOpeningDates = [
+      { open: "2024-03-12T10:00:00.000Z", close: "2024-03-12T18:00:00.000Z" },
       { open: "2024-03-13T10:00:00.000Z", close: "2024-03-13T18:00:00.000Z" },
       { open: "2024-03-14T10:00:00.000Z", close: "2024-03-14T20:00:00.000Z" },
       { open: "2024-03-15T10:00:00.000Z", close: "2024-03-15T18:00:00.000Z" },
@@ -133,7 +134,6 @@ describe("getNextOpeningDates", () => {
       { open: "2024-03-26T10:00:00.000Z", close: "2024-03-26T18:00:00.000Z" },
       { open: "2024-03-27T10:00:00.000Z", close: "2024-03-27T18:00:00.000Z" },
       { open: "2024-03-29T10:00:00.000Z", close: "2024-03-29T18:00:00.000Z" },
-      { open: "2024-04-02T09:00:00.000Z", close: "2024-04-02T17:00:00.000Z" },
     ];
 
     expect(

--- a/api/test/venues.test.ts
+++ b/api/test/venues.test.ts
@@ -112,6 +112,10 @@ const venueData = {
 
 const expectedNextOpeningDates = [
   {
+    open: "2024-04-02T09:00:00.000Z",
+    close: "2024-04-02T17:00:00.000Z",
+  },
+  {
     open: "2024-04-03T09:00:00.000Z",
     close: "2024-04-03T17:00:00.000Z",
   },
@@ -178,9 +182,5 @@ const expectedNextOpeningDates = [
   {
     open: "2024-04-22T09:00:00.000Z",
     close: "2024-04-22T17:00:00.000Z",
-  },
-  {
-    open: "2024-04-23T09:00:00.000Z",
-    close: "2024-04-23T17:00:00.000Z",
   },
 ];


### PR DESCRIPTION
## What does this change?

Following the discovery of a bug in the itemsAPI, we realised there was a mismatch between the content-api's venues response, and the way the itemsAPI was using it, ie. content-api starting the list of openingTimes at today+1 while itemsAPI assuming it started at "today" 
https://wellcome.slack.com/archives/C02ANCYL90E/p1714748440989459
It was decided that the content-api should respond with a list of openingTimes that start with "today" if today is an open day

## How to test

Running the api locally, hit `http://localhost:3000/venues?title=library` and check the `nextOpeningDates` start at today if today is an open day

## How can we measure success?

## Have we considered potential risks?

ItemsAPI is the only client of this endpoint. There will be checks there and in weco.org before this change is used by live systems

