### PR TITLE
Use shared stale pr workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,4 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: wellcomecollection/.github/.github/workflows/stale.yml@make-stalePR-workflow-reusable
+    uses: wellcomecollection/.github/.github/workflows/stale.yml@make-stalePR-workflow-reusable

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,11 +4,16 @@
 # Shamelessly copied from https://github.com/guardian/.github/blob/main/workflow-templates/stale.yml
 name: "Stale PR Handler"
 
+# on:
+#   schedule:
+#     # Check for Stale PRs every Monday to Thursday morning
+#     # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
+#     - cron: "0 6 * * MON-THU"
+
 on:
   schedule:
-    # Check for Stale PRs every Monday to Thursday morning
-    # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
-    - cron: "0 6 * * MON-THU"
+    # Check for Stale PRs every 5 minutes - temporary, for testing, then revert to the above
+    - cron: "*/5 * * * *"
 
 permissions:
   pull-requests: write
@@ -17,22 +22,4 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
-        id: stale
-        # Read about options here: https://github.com/actions/stale#all-options
-        with:
-          # never automatically mark issues as stale
-          days-before-issue-stale: -1
-
-          # Wait 30 days before marking a PR as stale
-          days-before-stale: 30
-          stale-pr-message: >
-            This PR is stale because it has been open 30 days with no activity.
-            Unless a comment is added or the “stale” label removed, this will be closed in 3 days
-
-          # Wait 3 days after a PR has been marked as stale before closing
-          days-before-close: 3
-          close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
-
-          # Ignore PR's raised by Dependabot
-          exempt-pr-labels: "dependencies"
+      - uses: wellcomecollection/.github/.github/workflows/stale.yml@make-stalePR-workflow-reusable


### PR DESCRIPTION
## What does this change?

The stale PR workflow will run every 5 minutes (temporarily) using a workflow stored in https://github.com/wellcomecollection/.github
The schedule will go back to everyday Monday-Thursday once we assert this works just as well as duplicating the workflows across the repos that run it

## How to test

Once this is merged, we should see within 5 minutes a Github action being triggered to run the shared workflow stored in the `.github` repo

## How can we measure success?

The github action gets triggered and runs successfully using a workflow from a different repo

## Have we considered potential risks?

Minimal. Worst case scenario, stale PRs do not get spotted and closed 

