### PR TITLE
Add ETL diagram to pipeline README

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -14,6 +14,9 @@ type Event = {
 
 It will then fetch documents between a given start and end, or for a duration before/after an end/start (respectively), or all documents if none of these parameters are specified.
 
+![generic-ETL](https://github.com/user-attachments/assets/ed1f6fd7-4111-4829-9f51-802fc77b742f)
+
+
 ## Tests
 
 The tests use snapshots of real Prismic data, and also save [Jest snapshots](https://jestjs.io/docs/snapshot-testing) of the expected output.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -16,7 +16,6 @@ It will then fetch documents between a given start and end, or for a duration be
 
 ![generic-ETL](https://github.com/user-attachments/assets/ed1f6fd7-4111-4829-9f51-802fc77b742f)
 
-
 ## Tests
 
 The tests use snapshots of real Prismic data, and also save [Jest snapshots](https://jestjs.io/docs/snapshot-testing) of the expected output.


### PR DESCRIPTION
## What does this change?

Following the creation of the diagram for the All Search RFC, I thought it'd be good to have a generic version added in here for future reference.

[See README file](https://github.com/wellcomecollection/content-api/blob/a211d6a408717abac81dceb24abfbb87bf849463/pipeline/README.md)
