### PR TITLE
Update types and add helpers to index addressables

### DIFF
--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "package": "./package.sh",
     "reindex": "tsx src/local.ts all",
+    "reindex-addressables": "tsx src/local.ts addressables",
     "reindex-articles": "tsx src/local.ts articles",
     "reindex-events": "tsx src/local.ts events",
     "reindex-venues": "tsx src/local.ts venues",

--- a/pipeline/src/event.ts
+++ b/pipeline/src/event.ts
@@ -1,7 +1,7 @@
 import parseDuration from 'parse-duration';
 
 export type WindowEvent = {
-  contentType: 'articles' | 'events' | 'venues' | 'all';
+  contentType: 'addressables' | 'articles' | 'events' | 'venues' | 'all';
   start?: string;
   end?: string;
   duration?: string;

--- a/pipeline/src/handler.ts
+++ b/pipeline/src/handler.ts
@@ -11,6 +11,7 @@ import {
 } from './graph-queries';
 // import { addressablesQuery } from './graph-queries/addressables';
 import { articles, events, venues } from './indices';
+// import { transformAddressable } from './transformers/addressables';
 import { transformArticle } from './transformers/article';
 import { transformEventDocument } from './transformers/eventDocument';
 import { transformVenue } from './transformers/venue';
@@ -31,7 +32,7 @@ import { Clients } from './types';
 //     'seasons',
 //     'visual-stories',
 //   ]),
-//   transformer: transformAddressables,
+//   transformer: transformAddressable,
 // });
 
 const loadArticles = createETLPipeline({

--- a/pipeline/src/handler.ts
+++ b/pipeline/src/handler.ts
@@ -9,11 +9,30 @@ import {
   webcomicsQuery,
   wrapQueries,
 } from './graph-queries';
+// import { addressablesQuery } from './graph-queries/addressables';
 import { articles, events, venues } from './indices';
 import { transformArticle } from './transformers/article';
 import { transformEventDocument } from './transformers/eventDocument';
 import { transformVenue } from './transformers/venue';
 import { Clients } from './types';
+
+// const loadAddressables = createETLPipeline({
+//   graphQuery: addressablesQuery,
+//   indexConfig: addressables,
+//   parentDocumentTypes: new Set([
+//     'articles',
+//     'books',
+//     'events',
+//     'exhibitions',
+//     'exhibition-texts',
+//     'exhibition-highlight-tours',
+//     'pages',
+//     'projects',
+//     'seasons',
+//     'visual-stories',
+//   ]),
+//   transformer: transformAddressables,
+// });
 
 const loadArticles = createETLPipeline({
   graphQuery: wrapQueries(articlesQuery, webcomicsQuery),
@@ -42,6 +61,9 @@ export const createHandler =
     if (!event.contentType) {
       throw new Error('Event contentType must be specified!');
     }
+    // if (event.contentType === 'all' || event.contentType === 'addressables') {
+    //   await loadAddressables(clients, event);
+    // }
     if (event.contentType === 'all' || event.contentType === 'articles') {
       await loadArticles(clients, event);
     }

--- a/pipeline/src/indices/addressables.ts
+++ b/pipeline/src/indices/addressables.ts
@@ -1,0 +1,150 @@
+import { IndicesIndexSettings } from '@elastic/elasticsearch/lib/api/types';
+
+export const index = 'addressables';
+
+export const mappings = {
+  dynamic: 'strict',
+  properties: {
+    id: {
+      type: 'keyword',
+    },
+    uid: {
+      type: 'keyword',
+    },
+    display: {
+      type: 'object',
+      enabled: false,
+    },
+    query: {
+      properties: {
+        type: {
+          type: 'text',
+          shingles: {
+            type: 'text',
+            analyzer: 'english_shingle_analyzer',
+          },
+          cased: {
+            type: 'text',
+            analyzer: 'english_cased_analyzer',
+          },
+          keyword: {
+            type: 'keyword',
+            normalizer: 'keyword_lowercase',
+          },
+        },
+        title: {
+          type: 'text',
+          fields: {
+            shingles: {
+              type: 'text',
+              analyzer: 'english_shingle_analyzer',
+            },
+            cased: {
+              type: 'text',
+              analyzer: 'english_cased_analyzer',
+            },
+            keyword: {
+              type: 'keyword',
+              normalizer: 'keyword_lowercase',
+            },
+          },
+        },
+        contributors: {
+          type: 'text',
+          fields: {
+            shingles: {
+              type: 'text',
+              analyzer: 'english_shingle_analyzer',
+            },
+            keyword: {
+              type: 'keyword',
+              normalizer: 'keyword_lowercase',
+            },
+          },
+        },
+        description: {
+          type: 'text',
+          fields: {
+            shingles: {
+              type: 'text',
+              analyzer: 'english_shingle_analyzer',
+            },
+            cased: {
+              type: 'text',
+              analyzer: 'english_cased_analyzer',
+            },
+          },
+        },
+        body: {
+          type: 'text',
+          fields: {
+            shingles: {
+              type: 'text',
+              analyzer: 'english_shingle_analyzer',
+            },
+            cased: {
+              type: 'text',
+              analyzer: 'english_cased_analyzer',
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+export const settings = {
+  analysis: {
+    normalizer: {
+      keyword_lowercase: {
+        type: 'custom',
+        filter: ['lowercase'],
+      },
+    },
+    filter: {
+      shingle_filter: {
+        type: 'shingle',
+        min_shingle_size: 2,
+        max_shingle_size: 4,
+        output_unigrams: true,
+      },
+      english_stemmer: {
+        type: 'stemmer',
+        language: 'english',
+      },
+      english_possessive_stemmer: {
+        type: 'stemmer',
+        language: 'possessive_english',
+      },
+      punctuation_token_filter: {
+        type: 'pattern_replace',
+        pattern: '[^0-9\\p{L}\\s]',
+        replacement: '',
+      },
+    },
+    analyzer: {
+      english_shingle_analyzer: {
+        filter: [
+          'lowercase',
+          'asciifolding',
+          'english_stemmer',
+          'english_possessive_stemmer',
+          'punctuation_token_filter',
+          'shingle_filter',
+        ],
+        type: 'custom',
+        tokenizer: 'standard',
+      },
+      english_cased_analyzer: {
+        filter: [
+          'asciifolding',
+          'english_stemmer',
+          'english_possessive_stemmer',
+          'punctuation_token_filter',
+        ],
+        type: 'custom',
+        tokenizer: 'standard',
+      },
+    },
+  },
+} as IndicesIndexSettings; // as const was not sufficient, here.

--- a/pipeline/src/indices/index.ts
+++ b/pipeline/src/indices/index.ts
@@ -1,5 +1,6 @@
+import * as addressables from './addressables';
 import * as articles from './articles';
 import * as events from './events';
 import * as venues from './venues';
 
-export { articles, events, venues };
+export { addressables, articles, events, venues };

--- a/pipeline/src/local.ts
+++ b/pipeline/src/local.ts
@@ -9,6 +9,7 @@ import { createPrismicClient } from './services/prismic';
 const prismicClient = createPrismicClient();
 
 const contentType = (process.argv[2] ?? 'all') as
+  | 'addressables'
   | 'articles'
   | 'events'
   | 'venues'

--- a/pipeline/src/transformers/addressables.ts
+++ b/pipeline/src/transformers/addressables.ts
@@ -1,0 +1,70 @@
+import {
+  ArticlePrismicDocument,
+  BookPrismicDocument,
+  EventPrismicDocument,
+  VisualStoryPrismicDocument,
+} from '@weco/content-pipeline/src/types/prismic';
+import {
+  ElasticsearchAddressableBook,
+  ElasticsearchAddressableVisualStory,
+} from '@weco/content-pipeline/src/types/transformed';
+
+import { transformAddressableBook } from './addressables/book';
+import { transformAddressableVisualStory } from './addressables/visualStory';
+
+export const transformAddressable = (
+  document:
+    | ArticlePrismicDocument
+    | BookPrismicDocument
+    | EventPrismicDocument
+    | VisualStoryPrismicDocument
+): ElasticsearchAddressableVisualStory | ElasticsearchAddressableBook => {
+  const { type } = document;
+
+  let transformedDocument;
+  switch (type) {
+    case 'articles':
+      // transformedDocument = transformAddressableBook(document);
+      break;
+    case 'books':
+      transformedDocument = transformAddressableBook(document);
+      break;
+    case 'events':
+      // transformedDocument = transformAddressableBook(document);
+      break;
+
+    // case 'exhibitions':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    // case 'exhibitions-texts':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    // case 'exhibitions-highlight-tours':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    // case 'pages':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    // case 'projects':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    // case 'seasons':
+    //   transformedDocument = transformAddressableBook(document);
+    //   break;
+
+    case 'visual-stories':
+      transformedDocument = transformAddressableVisualStory(document);
+      break;
+  }
+
+  if (transformedDocument) {
+    return transformedDocument;
+  } else {
+    throw new Error(`Type did not match any known addressable: ${type}`);
+  }
+};


### PR DESCRIPTION
## What does this change?
#153  and #156

Adds necessary types and helpers to index Addressables.
I've also added the "parent" transformer file that sends documents to their relevant transformer.

## How to test

We won't index right away I think, which is why some code is commented out, so no need to test the indexing as part of this PR. As long as TS and tests are happy, so are we for now I think?

## How can we measure success?

Eases further work

## Have we considered potential risks?
This isn't used yet so shouldn't have risks.