### PR TITLE
Add addressable book transformer

### DIFF
--- a/pipeline/src/scripts/testTransformer.ts
+++ b/pipeline/src/scripts/testTransformer.ts
@@ -116,14 +116,12 @@ async function main() {
 
       case 'book': {
         const doc = await client.getByID(id || 'WwVK3CAAAHm5Exxr', {
-          graphQuery: isDetailed
-            ? ''
-            : `{
+          graphQuery: `{
             ${addressablesBooksQuery}
           }`,
         });
 
-        transformerName = isDetailed ? '' : 'transformAddressableBook';
+        transformerName = 'transformAddressableBook';
         return transformAddressableBook(doc as BookPrismicDocument);
       }
 

--- a/pipeline/src/scripts/testTransformer.ts
+++ b/pipeline/src/scripts/testTransformer.ts
@@ -9,6 +9,7 @@ import {
 } from './../graph-queries';
 import { addressablesBooksQuery } from './../graph-queries/addressables';
 import { createPrismicClient } from './../services/prismic';
+import { transformAddressableBook } from './../transformers/addressables/book';
 import { transformArticle } from './../transformers/article';
 import { transformEventDocument } from './../transformers/eventDocument';
 import { transformVenue } from './../transformers/venue';
@@ -16,6 +17,7 @@ import {
   ArticlePrismicDocument,
   EventPrismicDocument,
 } from './../types/prismic';
+import { BookPrismicDocument } from './../types/prismic/books';
 import { VenuePrismicDocument } from './../types/prismic/venues';
 
 const { type, isDetailed, id } = yargs(process.argv.slice(2))
@@ -114,11 +116,15 @@ async function main() {
 
       case 'book': {
         const doc = await client.getByID(id || 'ZijgihEAACMAtL-k', {
-          graphQuery: venueQuery.replace(/\n(\s+)/g, '\n'),
+          graphQuery: isDetailed
+            ? ''
+            : `{
+            ${addressablesBooksQuery}
+          }`,
         });
 
-        transformerName = 'transformVenue';
-        return transformVenue(doc as VenuePrismicDocument);
+        transformerName = isDetailed ? '' : 'transformAddressableBook';
+        return transformAddressableBook(doc as BookPrismicDocument);
       }
 
       // case 'page': {

--- a/pipeline/src/scripts/testTransformer.ts
+++ b/pipeline/src/scripts/testTransformer.ts
@@ -115,7 +115,7 @@ async function main() {
       // }
 
       case 'book': {
-        const doc = await client.getByID(id || 'ZijgihEAACMAtL-k', {
+        const doc = await client.getByID(id || 'WwVK3CAAAHm5Exxr', {
           graphQuery: isDetailed
             ? ''
             : `{

--- a/pipeline/src/scripts/testTransformer.ts
+++ b/pipeline/src/scripts/testTransformer.ts
@@ -7,6 +7,7 @@ import {
   venueQuery,
   webcomicsQuery,
 } from './../graph-queries';
+import { addressablesBooksQuery } from './../graph-queries/addressables';
 import { createPrismicClient } from './../services/prismic';
 import { transformArticle } from './../transformers/article';
 import { transformEventDocument } from './../transformers/eventDocument';
@@ -111,14 +112,14 @@ async function main() {
       //   return transformVenue(doc as VenuePrismicDocument);
       // }
 
-      // case 'book': {
-      //   const doc = await client.getByID(id || 'ZijgihEAACMAtL-k', {
-      //     graphQuery: venueQuery.replace(/\n(\s+)/g, '\n'),
-      //   });
+      case 'book': {
+        const doc = await client.getByID(id || 'ZijgihEAACMAtL-k', {
+          graphQuery: venueQuery.replace(/\n(\s+)/g, '\n'),
+        });
 
-      //   transformerName = 'transformVenue';
-      //   return transformVenue(doc as VenuePrismicDocument);
-      // }
+        transformerName = 'transformVenue';
+        return transformVenue(doc as VenuePrismicDocument);
+      }
 
       // case 'page': {
       //   const doc = await client.getByID(id || 'YdXSvhAAAIAW7YXQ', {

--- a/pipeline/src/transformers/addressables/book.ts
+++ b/pipeline/src/transformers/addressables/book.ts
@@ -1,0 +1,48 @@
+import {
+  asText,
+  isFilledLinkToDocumentWithData,
+  isNotUndefined,
+} from '@weco/content-pipeline/src/helpers/type-guards';
+import { BooksAddressablePrismicDocument } from '@weco/content-pipeline/src/types/prismic/addressables/books';
+
+export const transformAddressableBook = (
+  document: BooksAddressablePrismicDocument
+) => {
+  const { data, id, uid } = document;
+  const primaryImage = data.promo?.[0]?.primary;
+  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const titleSubtitle = `${asText(data.title)} ${asText(data.subtitle)}`;
+  const contributors = (data.contributors ?? [])
+    .map(c => {
+      return isFilledLinkToDocumentWithData(c.contributor)
+        ? asText(c.contributor?.data.name)
+        : undefined;
+    })
+    .filter(isNotUndefined);
+
+  const body = data.body
+    ?.map(s => {
+      return s.primary.text.map(t => t.text);
+    })
+    .flat()
+    .join(' ');
+
+  return {
+    id,
+    uid,
+    display: {
+      type: 'Book',
+      id,
+      uid,
+      title: asText(data.title),
+      description,
+    },
+    query: {
+      type: 'Book',
+      title: titleSubtitle,
+      description,
+      contributors,
+      body,
+    },
+  };
+};

--- a/pipeline/src/transformers/addressables/book.ts
+++ b/pipeline/src/transformers/addressables/book.ts
@@ -22,7 +22,8 @@ export const transformAddressableBook = (
         ? asText(c.contributor?.data.name)
         : undefined;
     })
-    .filter(isNotUndefined);
+    .filter(isNotUndefined)
+    .join(', ');
 
   const body = data.body
     ?.map(s => {

--- a/pipeline/src/transformers/addressables/book.ts
+++ b/pipeline/src/transformers/addressables/book.ts
@@ -4,11 +4,11 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
-import { BooksPrismicDocument } from '@weco/content-pipeline/src/types/prismic/books';
+import { BookPrismicDocument } from '@weco/content-pipeline/src/types/prismic/books';
 import { ElasticsearchAddressableBook } from '@weco/content-pipeline/src/types/transformed';
 
 export const transformAddressableBook = (
-  document: BooksPrismicDocument
+  document: BookPrismicDocument
 ): ElasticsearchAddressableBook => {
   const { data, id, uid } = document;
   const primaryImage = data.promo?.[0]?.primary;
@@ -45,10 +45,9 @@ export const transformAddressableBook = (
     query: {
       type: 'Book',
       title,
-      subtitle,
       description,
-      contributors,
       body,
+      contributors,
     },
   };
 };

--- a/pipeline/src/transformers/addressables/book.ts
+++ b/pipeline/src/transformers/addressables/book.ts
@@ -44,7 +44,7 @@ export const transformAddressableBook = (
     },
     query: {
       type: 'Book',
-      title,
+      title: titleSubtitle,
       description,
       body,
       contributors,

--- a/pipeline/src/types/prismic/addressables/books.ts
+++ b/pipeline/src/types/prismic/addressables/books.ts
@@ -1,0 +1,12 @@
+import * as prismic from '@prismicio/client';
+
+import { CommonPrismicFields } from '@weco/content-pipeline/src/types/prismic/';
+import { WithBody } from '@weco/content-pipeline/src/types/prismic/body';
+import { WithContributors } from '@weco/content-pipeline/src/types/prismic/contributors';
+
+export type BooksAddressablePrismicDocument = prismic.PrismicDocument<
+  { subtitle: prismic.RichTextField } & WithContributors &
+    WithBody &
+    CommonPrismicFields,
+  'books'
+>;

--- a/pipeline/src/types/prismic/books.ts
+++ b/pipeline/src/types/prismic/books.ts
@@ -5,7 +5,7 @@ import { WithBody } from '@weco/content-pipeline/src/types/prismic/body';
 import { WithContributors } from '@weco/content-pipeline/src/types/prismic/contributors';
 
 export type BookPrismicDocument = prismic.PrismicDocument<
-  { subtitle: prismic.RichTextField } & WithContributors &
+  { subtitle?: prismic.RichTextField } & WithContributors &
     WithBody &
     CommonPrismicFields,
   'books'

--- a/pipeline/src/types/prismic/books.ts
+++ b/pipeline/src/types/prismic/books.ts
@@ -4,7 +4,7 @@ import { CommonPrismicFields } from '@weco/content-pipeline/src/types/prismic/';
 import { WithBody } from '@weco/content-pipeline/src/types/prismic/body';
 import { WithContributors } from '@weco/content-pipeline/src/types/prismic/contributors';
 
-export type BooksAddressablePrismicDocument = prismic.PrismicDocument<
+export type BooksPrismicDocument = prismic.PrismicDocument<
   { subtitle: prismic.RichTextField } & WithContributors &
     WithBody &
     CommonPrismicFields,

--- a/pipeline/src/types/prismic/books.ts
+++ b/pipeline/src/types/prismic/books.ts
@@ -4,7 +4,7 @@ import { CommonPrismicFields } from '@weco/content-pipeline/src/types/prismic/';
 import { WithBody } from '@weco/content-pipeline/src/types/prismic/body';
 import { WithContributors } from '@weco/content-pipeline/src/types/prismic/contributors';
 
-export type BooksPrismicDocument = prismic.PrismicDocument<
+export type BookPrismicDocument = prismic.PrismicDocument<
   { subtitle: prismic.RichTextField } & WithContributors &
     WithBody &
     CommonPrismicFields,

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -96,3 +96,25 @@ export type ElasticsearchEventDocument = {
     isAvailableOnline: string;
   };
 };
+
+export type ElasticsearchAddressableBook = {
+  id: string;
+  uid?: string;
+  display: {
+    type: 'Book';
+    id: string;
+    uid?: string;
+    title: string;
+    description?: string;
+    contributors: string[];
+  };
+  query: {
+    type: 'Book';
+    title: string;
+    subtitle?: string;
+    description?: string;
+    contributors: string[];
+    caption?: string;
+    body?: string[] | string;
+  };
+};

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -111,10 +111,8 @@ export type ElasticsearchAddressableBook = {
   query: {
     type: 'Book';
     title: string;
-    subtitle?: string;
     description?: string;
     contributors: string[];
-    caption?: string;
     body?: string[] | string;
   };
 };

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -106,13 +106,13 @@ export type ElasticsearchAddressableBook = {
     uid?: string;
     title: string;
     description?: string;
-    contributors: string[];
+    contributors: string;
   };
   query: {
     type: 'Book';
     title: string;
     description?: string;
-    contributors: string[];
-    body?: string[] | string;
+    contributors: string;
+    body?: string;
   };
 };


### PR DESCRIPTION
## What does this change?
First go at the first of the addressable transformers needed for #156

## How to test
`cd pipeline && yarn testTransformer --type book`

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/521be0e1-15ae-4a73-a2dc-dc9da129661d">

## How can we measure success?
We're a step closer to being able to display addressable content in 'All search'

## Have we considered potential risks?
Can't think of any

- [ ] @LaurenFBaily to confirm we are happy with `title: subtitle` in the `display` block

