### PR TITLE
script to test end of year closure in date picker

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "NODE_ENV=production tsx ./server.ts",
     "dev": "AWS_PROFILE=catalogue-developer NODE_ENV=development nodemon - exec 'tsx' ./server.ts",
-    "test": "jest"
+    "test": "jest",
+    "check_holiday_closures": "AWS_PROFILE=catalogue-developer tsx ./scripts/holiday_closure_test.ts"
   },
   "dependencies": {
     "@elastic/elasticsearch": "^8.6.0",

--- a/api/scripts/holiday_closure_test.ts
+++ b/api/scripts/holiday_closure_test.ts
@@ -1,0 +1,104 @@
+// Before the end-of-year closure, we test that the date picker dropdown in the Request item dialog is going to display the correct options
+// to ensure that users can only requests items when they can be available, on a day the library is open
+// Once the Modified opening times have been added to Prismic and published,
+// set dateNow in utils.ts as the date to be tested and run this script with
+// yarn check_holiday_closures
+
+import { DateTime } from 'luxon';
+import { getElasticClient } from '@weco/content-common/services/elasticsearch';
+import { ElasticsearchVenue, Venue } from '@weco/content-common/types/venue';
+import { getNextOpeningDates } from '@weco/content-api/src/controllers/utils';
+import { NextOpeningDate } from '@weco/content-common/types/venue';
+
+// set this to the date to be tested
+const dateNow = new Date();
+
+const formatDate = (openingDay: NextOpeningDate) =>
+  openingDay.open
+    ? new Date(openingDay.open).toUTCString().slice(0, 11) + '\n'
+    : '';
+
+const compareDates = (library: NextOpeningDate, deepstore: NextOpeningDate) => {
+  const libraryDate =
+    library.open && DateTime.fromJSDate(new Date(library.open)).startOf('day');
+  const deepstoreDate =
+    deepstore.open &&
+    DateTime.fromJSDate(new Date(deepstore.open)).startOf('day');
+  if (libraryDate === undefined || deepstoreDate === undefined) {
+    throw 'One of these dates is undefined!';
+  } else {
+    return libraryDate > deepstoreDate;
+  }
+};
+
+// the 2 functions below reproduce the logic used in the catalogue-api/items to generate available dates
+
+const applyItemsApiLibraryLogic = (openingTimes: NextOpeningDate[]) => {
+  // the library is open today if the 1st date in NextOpeningDate[] is the same as today
+  const isLibraryOpenToday =
+    new Date(dateNow).getDate() ===
+    (openingTimes[0].open && new Date(openingTimes[0].open).getDate());
+  if (dateNow.getHours() < 10 || !isLibraryOpenToday) {
+    return openingTimes.slice(1, -1).map(formatDate);
+  } else {
+    return openingTimes.slice(2, -1).map(formatDate);
+  }
+};
+
+const applyItemsApiDeepstoreLogic = (
+  libraryOpeningTimes: NextOpeningDate[],
+  deepstoreOpeningTimes: NextOpeningDate[]
+) => {
+  const firstDeepstoreAvailability = deepstoreOpeningTimes.slice(10, -1)[0];
+  const subsequentLibraryAvailabilities = libraryOpeningTimes.filter(
+    libraryOpeningTime => {
+      return compareDates(libraryOpeningTime, firstDeepstoreAvailability);
+    }
+  );
+  return subsequentLibraryAvailabilities.map(formatDate);
+};
+
+const run = async () => {
+  const elasticClient = await getElasticClient({
+    serviceName: 'api',
+    pipelineDate: '2023-03-24',
+    hostEndpointAccess: 'public',
+  });
+
+  const searchResponse = await elasticClient.search<ElasticsearchVenue>({
+    index: 'venues',
+    _source: ['display'],
+    query: {
+      bool: {
+        filter: [{ terms: { 'filter.title': ['library', 'deepstore'] } }],
+      },
+    },
+  });
+  const venuesData = searchResponse.hits.hits.flatMap(hit =>
+    hit._source ? [hit._source.display] : []
+  );
+
+  const {
+    regularOpeningDays: libraryRegularOpeningDays,
+    exceptionalClosedDays: libraryHolidayclosures,
+  } = venuesData.find(venue => venue.title === 'Library') as Venue;
+  const {
+    regularOpeningDays: deepstoreRegularOpeningDays,
+    exceptionalClosedDays: deepstoreHolidayclosures,
+  } = venuesData.find(venue => venue.title === 'Deepstore') as Venue;
+
+  const onsiteItemsPickup = applyItemsApiLibraryLogic(
+    getNextOpeningDates(libraryRegularOpeningDays, libraryHolidayclosures)
+  ).slice(0, 12);
+  const offsiteItemsPickup = applyItemsApiDeepstoreLogic(
+    getNextOpeningDates(libraryRegularOpeningDays, libraryHolidayclosures),
+    getNextOpeningDates(deepstoreRegularOpeningDays, deepstoreHolidayclosures)
+  ).slice(0, 12);
+
+  const library = `Onsite items requested on ${dateNow} will be available on: \n${onsiteItemsPickup.join('\r')}`;
+  const deepstore = `Deepstore items requested on ${dateNow} will be available on: \n${offsiteItemsPickup.join('\r')}`;
+  console.log(library);
+  console.log(deepstore);
+};
+
+run();

--- a/api/scripts/holiday_closure_test.ts
+++ b/api/scripts/holiday_closure_test.ts
@@ -1,16 +1,24 @@
-// Before the end-of-year closure, we test that the date picker dropdown in the Request item dialog is going to display the correct options
-// to ensure that users can only requests items when they can be available, on a day the library is open
-// Once the Modified opening times have been added to Prismic and published,
-// set dateNow in utils.ts as the date to be tested and run this script with
-// yarn check_holiday_closures
+/* 
+Before the end-of-year closure, we test that the date picker dropdown in the Request item dialog is going to display the correct options
+to ensure that users can only requests items when they can be available, on a day the library is open
+Once the Modified opening times have been added to Prismic and published,
+set dateNow as the date to be tested and run this script with
+yarn check_holiday_closures
+*/
 
 import { DateTime } from 'luxon';
-import { getElasticClient } from '@weco/content-common/services/elasticsearch';
-import { ElasticsearchVenue, Venue } from '@weco/content-common/types/venue';
-import { getNextOpeningDates } from '@weco/content-api/src/controllers/utils';
-import { NextOpeningDate } from '@weco/content-common/types/venue';
 
-// set this to the date to be tested
+import { getNextOpeningDates } from '@weco/content-api/src/controllers/utils';
+import { getElasticClient } from '@weco/content-common/services/elasticsearch';
+import {
+  ElasticsearchVenue,
+  NextOpeningDate,
+  Venue,
+} from '@weco/content-common/types/venue';
+
+// set this to the date to be tested, here and in utils.ts
+// eg. if you want to see what the dates on the date picker will be on December 14, 2024 at 8:30am
+// const dateNow = new Date("2024-12-14T08:30:00.000Z");
 const dateNow = new Date();
 
 const formatDate = (openingDay: NextOpeningDate) =>
@@ -25,7 +33,7 @@ const compareDates = (library: NextOpeningDate, deepstore: NextOpeningDate) => {
     deepstore.open &&
     DateTime.fromJSDate(new Date(deepstore.open)).startOf('day');
   if (libraryDate === undefined || deepstoreDate === undefined) {
-    throw 'One of these dates is undefined!';
+    throw new Error('One of these dates is undefined!');
   } else {
     return libraryDate > deepstoreDate;
   }


### PR DESCRIPTION
## What does this change?

The logic that generates dates for the date picker dropdown (items request) now live across applications.
This script can be run to easily check what dates will be listed on any given day

## How to test
Set `dateNow` as the date you want to test
Run `yarn check_holiday_closures`

## How can we measure success?

We're confident that the date picker will display correct dates over the holiday closure

## Have we considered potential risks?

If the logic changes in the catalogue-api, this script will need updating too

