### PR TITLE
Add addressables API query

### DIFF
--- a/api/src/queries/addressables.ts
+++ b/api/src/queries/addressables.ts
@@ -1,0 +1,21 @@
+import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
+
+export const addressablesQuery = (
+  queryString: string
+): QueryDslQueryContainer => ({
+  multi_match: {
+    query: queryString,
+    fields: [
+      'id',
+      'uid',
+      'query.title.*^100',
+      'query.contributors.*^10',
+      'query.contributors.keyword^100',
+      'query.body.*',
+      'query.description.*',
+    ],
+    operator: 'or',
+    type: 'cross_fields',
+    minimum_should_match: '-25%',
+  },
+});


### PR DESCRIPTION
For #166 

## What does this change?

Adds the API query for addressables. It doesn't include any filtering or aggregation, in line with what was [decided in the RFC](https://github.com/wellcomecollection/docs/tree/main/rfcs/062-content-api-all-search#background-information).

## How to test
This query isn't connected to a controller (coming in #167) so doesn't require testing yet because it isn't doing anything.

## How can we measure success?
n/a

## Have we considered potential risks?
n/a