### PR TITLE
Terraform: Wrap role_arn in assume_role

### DIFF
--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -1,6 +1,8 @@
 terraform {
   backend "s3" {
-    role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
+    assume_role = {
+      role_arn = "arn:aws:iam::756629837203:role/catalogue-developer"
+    }
 
     bucket         = "wellcomecollection-catalogue-infra-delta"
     key            = "terraform/content-api/content_api.tfstate"
@@ -29,7 +31,9 @@ data "terraform_remote_state" "accounts_catalogue" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/aws-account-infrastructure/catalogue.tfstate"
@@ -41,7 +45,9 @@ data "terraform_remote_state" "infra_critical" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/platform-infrastructure/shared.tfstate"
@@ -53,7 +59,9 @@ data "terraform_remote_state" "monitoring" {
   backend = "s3"
 
   config = {
-    role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-read_only"
+    }
 
     bucket = "wellcomecollection-platform-infra"
     key    = "terraform/monitoring.tfstate"


### PR DESCRIPTION
## What does this change?

Updated Terraform to v1.10.1 and this was required ([see github ticket](https://github.com/hashicorp/terraform/issues/36124))

The update means we can't run `terraform [command]` anymore and have to go through `./run_terraform.sh [command]` instead as that's where it fetches the required secrets from AWS.

## How to test

[Update your terraform](https://developer.hashicorp.com/terraform/install)
`cd infrastructure && terraform init -reconfigure && ./run_terraform.sh plan`

## How can we measure success?

Up to date and no changes are flagged on plan

## Have we considered potential risks?
N/A