### PR TITLE
uid shouldn't be optional

### DIFF
--- a/pipeline/src/types/transformed/addressables.ts
+++ b/pipeline/src/types/transformed/addressables.ts
@@ -31,7 +31,7 @@ export type ElasticsearchAddressable<
   U extends Record<string, unknown> = Record<string, unknown>,
 > = {
   id: string;
-  uid?: string;
+  uid: string;
   display: AddressableBaseDisplay<T> & U;
   query: AddressableQuery<T>;
 };


### PR DESCRIPTION
## What does this change?

Changes the addressables base type to make the uid required. It should always be available for these types and is what we use to construct the human readable urls.


## How to test

n/a

## How can we measure success?

It now matches what we specify in the[ developer docs](https://github.com/wellcomecollection/developers.wellcomecollection.org/pull/45/files)

## Have we considered potential risks?

n/a
