### PR TITLE
Move caption/description logic into a helper

### DIFF
--- a/pipeline/src/transformers/addressables/article.ts
+++ b/pipeline/src/transformers/addressables/article.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { ArticlePrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableArticle } from '@weco/content-pipeline/src/types/transformed';
 
@@ -12,8 +13,7 @@ export const transformAddressableArticle = (
 ): ElasticsearchAddressableArticle[] => {
   const { data, id, uid, type } = document;
 
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const title = asTitle(data.title);
 
   const format = isFilledLinkToDocumentWithData(data.format)

--- a/pipeline/src/transformers/addressables/book.ts
+++ b/pipeline/src/transformers/addressables/book.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { BookPrismicDocument } from '@weco/content-pipeline/src/types/prismic/books';
 import { ElasticsearchAddressableBook } from '@weco/content-pipeline/src/types/transformed';
 
@@ -11,8 +12,7 @@ export const transformAddressableBook = (
   document: BookPrismicDocument
 ): ElasticsearchAddressableBook[] => {
   const { data, id, uid, type } = document;
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const title = asTitle(data.title);
   const subtitle = data.subtitle ? asText(data.subtitle) : undefined;
   const titleSubtitle = `${title}${subtitle ? `: ${subtitle}` : ''}`;

--- a/pipeline/src/transformers/addressables/event.ts
+++ b/pipeline/src/transformers/addressables/event.ts
@@ -6,6 +6,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { EventPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableEvent } from '@weco/content-pipeline/src/types/transformed';
 
@@ -38,8 +39,7 @@ export const transformAddressableEvent = (
         }
       : undefined;
 
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const queryDescription = [description, format].filter(isNotUndefined);
   const title = asTitle(data.title);
   const contributors = (data.contributors ?? [])

--- a/pipeline/src/transformers/addressables/exhibition.ts
+++ b/pipeline/src/transformers/addressables/exhibition.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { ExhibitionPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableExhibition } from '@weco/content-pipeline/src/types/transformed';
 
@@ -20,8 +21,7 @@ export const transformAddressableExhibition = (
     end: data.end,
   };
 
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const queryDescription = [description, format].filter(isNotUndefined);
   const title = asTitle(data.title);
   const contributors = (data.contributors ?? [])

--- a/pipeline/src/transformers/addressables/exhibitionHighlightTour.ts
+++ b/pipeline/src/transformers/addressables/exhibitionHighlightTour.ts
@@ -22,9 +22,8 @@ export const transformAddressableExhibitionHighlightTour = (
     : undefined;
   const exhibitionTitle = exhibitionTitleField && asTitle(exhibitionTitleField);
   const introText = data.intro_text && asText(data.intro_text);
-  const promoCaption = primaryImageCaption(relatedExhibition?.data.promo);
-
-  const description = introText ?? promoCaption;
+  const description =
+    introText ?? primaryImageCaption(relatedExhibition?.data.promo);
 
   const audioTitle = `${exhibitionTitle} audio highlight tour`;
   const bslTitle = `${exhibitionTitle} British Sign Language tour`;

--- a/pipeline/src/transformers/addressables/exhibitionHighlightTour.ts
+++ b/pipeline/src/transformers/addressables/exhibitionHighlightTour.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { ExhibitionHighlightTourPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableExhibitionHighlightTour } from '@weco/content-pipeline/src/types/transformed';
 
@@ -21,11 +22,7 @@ export const transformAddressableExhibitionHighlightTour = (
     : undefined;
   const exhibitionTitle = exhibitionTitleField && asTitle(exhibitionTitleField);
   const introText = data.intro_text && asText(data.intro_text);
-  const primaryImage = relatedExhibition
-    ? relatedExhibition.data.promo?.[0]?.primary
-    : undefined;
-
-  const promoCaption = primaryImage?.caption && asText(primaryImage.caption);
+  const promoCaption = primaryImageCaption(relatedExhibition?.data.promo);
 
   const description = introText ?? promoCaption;
 

--- a/pipeline/src/transformers/addressables/exhibitionText.ts
+++ b/pipeline/src/transformers/addressables/exhibitionText.ts
@@ -21,9 +21,8 @@ export const transformAddressableExhibitionText = (
     ? relatedExhibition.data.title
     : undefined;
   const introText = data.intro_text && asText(data.intro_text);
-  const promoCaption = primaryImageCaption(relatedExhibition?.data.promo);
-
-  const description = introText || promoCaption || undefined;
+  const description =
+    introText ?? primaryImageCaption(relatedExhibition?.data.promo);
   const queryDescription = description ? [description] : undefined;
 
   const title = asTitle(data.title);

--- a/pipeline/src/transformers/addressables/exhibitionText.ts
+++ b/pipeline/src/transformers/addressables/exhibitionText.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { ExhibitionTextPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableExhibitionText } from '@weco/content-pipeline/src/types/transformed';
 
@@ -20,11 +21,7 @@ export const transformAddressableExhibitionText = (
     ? relatedExhibition.data.title
     : undefined;
   const introText = data.intro_text && asText(data.intro_text);
-  const primaryImage = relatedExhibition
-    ? relatedExhibition.data.promo?.[0]?.primary
-    : undefined;
-
-  const promoCaption = primaryImage?.caption && asText(primaryImage.caption);
+  const promoCaption = primaryImageCaption(relatedExhibition?.data.promo);
 
   const description = introText || promoCaption || undefined;
   const queryDescription = description ? [description] : undefined;

--- a/pipeline/src/transformers/addressables/page.ts
+++ b/pipeline/src/transformers/addressables/page.ts
@@ -3,6 +3,7 @@ import {
   asTitle,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { PagePrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressablePage } from '@weco/content-pipeline/src/types/transformed';
 
@@ -11,8 +12,7 @@ export const transformAddressablePage = (
 ): ElasticsearchAddressablePage[] => {
   const { data, id, uid, tags, type } = document;
 
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const introText = data.introText && asText(data.introText);
   const queryDescription = [description, introText].filter(isNotUndefined);
   const title = asTitle(data.title);

--- a/pipeline/src/transformers/addressables/project.ts
+++ b/pipeline/src/transformers/addressables/project.ts
@@ -4,6 +4,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { ProjectPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableProject } from '@weco/content-pipeline/src/types/transformed';
 
@@ -24,8 +25,7 @@ export const transformAddressableProject = (
     })
     .filter(isNotUndefined)
     .join(', ');
-  const primaryImage = data.promo?.[0]?.primary;
-  const promoCaption = primaryImage?.caption && asText(primaryImage.caption);
+  const promoCaption = primaryImageCaption(data.promo);
   const displayDescription = promoCaption;
   const queryDescription = [promoCaption, format].filter(isNotUndefined);
   const queryBody = data.body

--- a/pipeline/src/transformers/addressables/project.ts
+++ b/pipeline/src/transformers/addressables/project.ts
@@ -25,9 +25,8 @@ export const transformAddressableProject = (
     })
     .filter(isNotUndefined)
     .join(', ');
-  const promoCaption = primaryImageCaption(data.promo);
-  const displayDescription = promoCaption;
-  const queryDescription = [promoCaption, format].filter(isNotUndefined);
+  const description = primaryImageCaption(data.promo);
+  const queryDescription = [description, format].filter(isNotUndefined);
   const queryBody = data.body
     ?.map(slice => {
       if (['text', 'quote', 'standfirst'].includes(slice.slice_type)) {
@@ -48,7 +47,7 @@ export const transformAddressableProject = (
         uid,
         title,
         format,
-        description: displayDescription,
+        description,
       },
       query: {
         type: 'Project',

--- a/pipeline/src/transformers/addressables/season.ts
+++ b/pipeline/src/transformers/addressables/season.ts
@@ -13,12 +13,11 @@ export const transformAddressableSeason = (
 
   const title = asTitle(data.title);
 
-  const promoCaption = primaryImageCaption(data.promo);
+  const description = primaryImageCaption(data.promo);
 
   const standfirst = data.body?.find(b => b.slice_type === 'standfirst')
     ?.primary.text[0].text;
-  const displayDescription = promoCaption;
-  const queryDescription = [promoCaption, standfirst].filter(isNotUndefined);
+  const queryDescription = [description, standfirst].filter(isNotUndefined);
   const queryBody = data.body
     ?.map(slice => {
       if (['text', 'quote', 'standfirst'].includes(slice.slice_type)) {
@@ -38,7 +37,7 @@ export const transformAddressableSeason = (
         id,
         uid,
         title,
-        description: displayDescription,
+        description,
       },
       query: {
         type: 'Season',

--- a/pipeline/src/transformers/addressables/season.ts
+++ b/pipeline/src/transformers/addressables/season.ts
@@ -1,8 +1,8 @@
 import {
-  asText,
   asTitle,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { SeasonPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableSeason } from '@weco/content-pipeline/src/types/transformed';
 
@@ -12,8 +12,9 @@ export const transformAddressableSeason = (
   const { data, id, uid, type } = document;
 
   const title = asTitle(data.title);
-  const primaryImage = data.promo?.[0]?.primary;
-  const promoCaption = primaryImage?.caption && asText(primaryImage.caption);
+
+  const promoCaption = primaryImageCaption(data.promo);
+
   const standfirst = data.body?.find(b => b.slice_type === 'standfirst')
     ?.primary.text[0].text;
   const displayDescription = promoCaption;

--- a/pipeline/src/transformers/addressables/visualStory.ts
+++ b/pipeline/src/transformers/addressables/visualStory.ts
@@ -1,7 +1,5 @@
-import {
-  asText,
-  asTitle,
-} from '@weco/content-pipeline/src/helpers/type-guards';
+import { asTitle } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import { VisualStoryPrismicDocument } from '@weco/content-pipeline/src/types/prismic';
 import { ElasticsearchAddressableVisualStory } from '@weco/content-pipeline/src/types/transformed';
 
@@ -10,8 +8,7 @@ export const transformAddressableVisualStory = (
 ): ElasticsearchAddressableVisualStory[] => {
   const { data, id, uid, type } = document;
 
-  const primaryImage = data.promo?.[0]?.primary;
-  const description = primaryImage?.caption && asText(primaryImage.caption);
+  const description = primaryImageCaption(data.promo);
   const title = asTitle(data.title);
 
   return [

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -8,6 +8,7 @@ import {
   isImageLink,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { primaryImageCaption } from '@weco/content-pipeline/src/transformers/utils';
 import {
   ArticlePrismicDocument,
   WithArticleFormat,
@@ -95,7 +96,7 @@ export const transformArticle = (
       ? { type: 'PrismicImage' as const, ...primaryImage.image }
       : undefined;
 
-  const caption = primaryImage?.caption && asText(primaryImage.caption);
+  const caption = primaryImageCaption(data.promo);
 
   const format = transformLabelType(document);
 

--- a/pipeline/src/transformers/utils.ts
+++ b/pipeline/src/transformers/utils.ts
@@ -5,6 +5,7 @@ import {
   isFilledLinkToDocumentWithData,
   isNotUndefined,
 } from '@weco/content-pipeline/src/helpers/type-guards';
+import { PromoSliceZone } from '@weco/content-pipeline/src/types/prismic';
 import { WithSeries } from '@weco/content-pipeline/src/types/prismic/series';
 import { Series } from '@weco/content-pipeline/src/types/transformed';
 
@@ -78,3 +79,8 @@ export const transformSeries = (
       : []
   );
 };
+
+export function primaryImageCaption(promo?: PromoSliceZone) {
+  const primaryImage = promo?.[0]?.primary;
+  return primaryImage?.caption && asText(primaryImage.caption);
+}


### PR DESCRIPTION
## What does this change?

We had a lot of repeated code to get the caption from a promo image. This adds a helper to get the caption.

## How to test

`cd pipeline && yarn test` – snapshots still pass

## How can we measure success?

We have fewer places for bugs to be introduced and a more straightforward path for updating the logic in future if necessary.

## Have we considered potential risks?

This is the first time I've looked at a code editor since 2024.

