### PR TITLE
Streamline the test scripts

### DIFF
--- a/pipeline/src/helpers/getGraphQuery.ts
+++ b/pipeline/src/helpers/getGraphQuery.ts
@@ -30,13 +30,21 @@ export const allowedTypes = [
   'visual-story',
   'project',
   'season',
-];
+] as const;
+export type AddressablesAllowedTypes = (typeof allowedTypes)[number];
+
+export const isAddressablesAllowedTypes = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type: any
+): type is AddressablesAllowedTypes => {
+  return allowedTypes.includes(type);
+};
 
 export const getGraphQuery = ({
   type,
   isDetailed,
 }: {
-  type: (typeof allowedTypes)[number];
+  type: AddressablesAllowedTypes;
   isDetailed?: boolean;
 }) => {
   switch (type) {

--- a/pipeline/src/scripts/documentIds.ts
+++ b/pipeline/src/scripts/documentIds.ts
@@ -1,0 +1,26 @@
+import { AddressablesAllowedTypes } from '@weco/content-pipeline/src/helpers/getGraphQuery';
+
+const documentIds: { [key: string]: string | undefined } = {
+  article: 'ZdSMbREAACQA3j30',
+  webcomic: 'XkV9dREAAAPkNP0b',
+  event: 'ZfhSyxgAACQAkLPZ',
+  venue: 'Wsttgx8AAJeSNmJ4',
+  exhibition: 'Yzv9ChEAABfUrkVp',
+  book: 'ZijgihEAACMAtL-',
+  page: 'YdXSvhAAAIAW7YXQ',
+  'visual-story': 'Zs8EuRAAAB4APxrA',
+  'exhibition-text': 'Zs8mohAAAB4AP4sc',
+  'exhibition-highlight-tour': 'ZthrZRIAACQALvCC',
+  project: 'Ys1-xEAACEAguyS',
+  season: 'X84FvhIAACUAqiqp',
+};
+
+export const getDocumentId = ({
+  type,
+  id,
+}: {
+  type: AddressablesAllowedTypes;
+  id?: string;
+}): string | undefined => {
+  return id || documentIds[type];
+};

--- a/pipeline/src/scripts/testGraphQuery.ts
+++ b/pipeline/src/scripts/testGraphQuery.ts
@@ -2,10 +2,14 @@ import util from 'util';
 import yargs from 'yargs';
 
 import {
+  AddressablesAllowedTypes,
   allowedTypes,
   getGraphQuery,
+  isAddressablesAllowedTypes,
 } from '@weco/content-pipeline/src/helpers/getGraphQuery';
 import { createPrismicClient } from '@weco/content-pipeline/src/services/prismic';
+
+import { getDocumentId } from './documentIds';
 
 const { type, isDetailed, id } = yargs(process.argv.slice(2))
   .usage('Usage: $0 --type [string] --isDetailed [boolean] --id [string]')
@@ -16,129 +20,87 @@ const { type, isDetailed, id } = yargs(process.argv.slice(2))
   })
   .parseSync();
 
+const getGraphQueryName = ({
+  type,
+  isDetailed,
+}: {
+  type: AddressablesAllowedTypes;
+  isDetailed?: boolean;
+}) => {
+  switch (type) {
+    case 'article':
+      return isDetailed ? 'articlesQuery' : 'addressablesArticlesQuery';
+
+    case 'webcomic':
+      return 'webcomicsQuery';
+
+    case 'event':
+      return isDetailed ? 'eventDocumentsQuery' : 'addressablesEventsQuery';
+
+    case 'venue':
+      return 'venueQuery';
+
+    case 'exhibition':
+      return 'addressablesExhibitionsQuery';
+
+    case 'book':
+      return 'addressablesBooksQuery';
+
+    case 'page':
+      return 'addressablesPagesQuery';
+
+    case 'visual-story':
+      return 'addressablesVisualStoriesQuery';
+
+    case 'exhibition-text':
+      return 'addressablesExhibitionTextsQuery';
+
+    case 'exhibition-highlight-tour':
+      return 'addressablesExhibitionHighlightToursQuery';
+
+    case 'project':
+      return 'addressablesProjectsQuery';
+
+    case 'season':
+      return 'addressablesSeasonsQuery';
+
+    default:
+      console.error(`Allowed types are ${allowedTypes.join(', ')}.`);
+      process.exit(1);
+  }
+};
+
 async function main() {
-  if (!type) {
+  if (!isAddressablesAllowedTypes(type)) {
     console.error(
       `Please pass in the type you'd like to fetch, from this list ${allowedTypes.join(', ')}.\n e.g. --type=article`
     );
     process.exit(1);
   }
 
-  const client = createPrismicClient();
-
-  const getGraphInfo = ({
-    type,
-    isDetailed,
-    id,
-  }: {
-    type: (typeof allowedTypes)[number];
-    isDetailed?: boolean;
-    id?: string;
-  }) => {
-    switch (type) {
-      case 'article':
-        return {
-          graphQueryName: isDetailed
-            ? 'articlesQuery'
-            : 'addressablesArticlesQuery',
-          id: id || 'ZdSMbREAACQA3j30',
-        };
-
-      case 'webcomic':
-        return {
-          graphQueryName: 'webcomicsQuery',
-          id: id || 'XkV9dREAAAPkNP0b',
-        };
-
-      case 'event':
-        return {
-          graphQueryName: isDetailed
-            ? 'eventDocumentsQuery'
-            : 'addressablesEventsQuery',
-          id: id || 'ZfhSyxgAACQAkLPZ',
-        };
-
-      case 'venue':
-        return {
-          graphQueryName: 'venueQuery',
-          id: id || 'Wsttgx8AAJeSNmJ4',
-        };
-
-      case 'exhibition':
-        return {
-          graphQueryName: 'addressablesExhibitionsQuery',
-          id: id || 'Yzv9ChEAABfUrkVp',
-        };
-
-      case 'book':
-        return {
-          graphQueryName: 'addressablesBooksQuery',
-          id: id || 'ZijgihEAACMAtL-k',
-        };
-
-      case 'page':
-        return {
-          graphQueryName: 'addressablesPagesQuery',
-          id: id || 'YdXSvhAAAIAW7YXQ',
-        };
-
-      case 'visual-story':
-        return {
-          graphQueryName: 'addressablesVisualStoriesQuery',
-          id: id || 'Zs8EuRAAAB4APxrA',
-        };
-
-      case 'exhibition-text':
-        return {
-          graphQueryName: 'addressablesExhibitionTextsQuery',
-          id: id || 'Zs8mohAAAB4AP4sc',
-        };
-
-      case 'exhibition-highlight-tour':
-        return {
-          graphQueryName: 'addressablesExhibitionHighlightToursQuery',
-          id: id || 'ZthrZRIAACQALvCC',
-        };
-
-      case 'project':
-        return {
-          graphQueryName: 'addressablesProjectsQuery',
-          id: id || 'Ys1-OxEAACEAguyS',
-        };
-
-      case 'season':
-        return {
-          graphQueryName: 'addressablesSeasonsQuery',
-          id: id || 'X84FvhIAACUAqiqp',
-        };
-
-      default:
-        console.error(`Allowed types are ${allowedTypes.join(', ')}.`);
-        process.exit(1);
-    }
-  };
-
-  const graphInfo = getGraphInfo({ type, isDetailed, id });
+  const documentId = getDocumentId({ type, id });
+  const graphQueryName = getGraphQueryName({ type, isDetailed });
   const graphQuery = getGraphQuery({ type, isDetailed });
 
-  if (!graphInfo || !graphQuery) {
+  if (!documentId || !graphQueryName || !graphQuery) {
     console.error('Something went wrong with queryResult', {
-      graphInfo,
+      documentId,
+      graphQueryName,
       hasGraphQuery: !!graphQuery,
     });
     process.exit(1);
   }
 
-  const doc = await client.getByID(graphInfo.id, {
+  const client = createPrismicClient();
+
+  const doc = await client.getByID(documentId, {
     graphQuery: graphQuery.replace(/\n(\s+)/g, '\n'),
   });
 
   console.log(
     util.inspect(doc, { showHidden: false, depth: null, colors: true })
   );
-  console.log(
-    `\n\x1b[4mThis is the result from ${graphInfo.graphQueryName}.\x1b[0m\n`
-  );
+  console.log(`\n\x1b[4mThis is the result from ${graphQueryName}.\x1b[0m\n`);
 }
 
 main();

--- a/pipeline/test/update-prismic-snapshots.ts
+++ b/pipeline/test/update-prismic-snapshots.ts
@@ -11,7 +11,11 @@ import {
   webcomicsQuery,
   wrapQueries,
 } from '@weco/content-pipeline/src/graph-queries';
-import { getGraphQuery } from '@weco/content-pipeline/src/helpers/getGraphQuery';
+import {
+  allowedTypes,
+  getGraphQuery,
+  isAddressablesAllowedTypes,
+} from '@weco/content-pipeline/src/helpers/getGraphQuery';
 import {
   asText,
   asTitle,
@@ -124,6 +128,12 @@ const updateAddressablesSnapshots = async (client: Client) => {
 
   const docs = await Promise.all(
     Object.entries(addressableIds).map(async ([key, value]) => {
+      if (!isAddressablesAllowedTypes(key)) {
+        console.error(
+          `Please pass in the type you'd like to fetch, from this list ${allowedTypes.join(', ')}.\n e.g. --type=article`
+        );
+        process.exit(1);
+      }
       const graphQuery = getGraphQuery({ type: key });
 
       const newDoc = await client.getByID(value, {


### PR DESCRIPTION
## What does this change?

[Gareth's work here](https://github.com/wellcomecollection/content-api/pull/177/files#diff-33957a3cb92ea5451826ae598642e42bf69c37c6a6bbcff8f9505f544d2b9157), where he rightly reused existing helpers made me realise that we were repeating some logic and defaults IDs at various points. I wanted to streamline it, make it potentially easier to add new types to (although when will that ever happen 😄 ). Would recommend [reviewing without whitespace](https://github.com/wellcomecollection/content-api/pull/194/files?diff=split&w=1).

- Streamlines the test scripts to have one source of truth for default IDs
- Fixes the allowedtypes type, which wasn't working, we could enter whatever value and it would work

I do think it helps with readability and maintainability as well.

## How to test

Run some tests scripts, see if it's expected results!
Run `update-prismic-snapshot` to see if it still works as expected.

## How can we measure success?

Typescript is actually useful and we can add types/modify the tests/default IDs easily and in one place.

## Have we considered potential risks?
This is mostly for testing purposes, but it also affected `update-prismic-snapshot`, so there could be that, although the only change is a check if the type isn't valid. I re-ran the snapshots locally and it looks alright to me.
