### PR TITLE
Change to pipeline 2025-01-20

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  LIVE_PIPELINE: '2024-12-10'
+  LIVE_PIPELINE: '2025-01-20'
 steps:
   - label: 'autoformat'
     command: '.buildkite/scripts/autoformat.sh'

--- a/api/config.ts
+++ b/api/config.ts
@@ -12,7 +12,7 @@ const environment = environmentSchema.parse(process.env);
 // This configuration is exposed via the public healthcheck endpoint,
 // so be careful not to expose any secrets here.
 const config = {
-  pipelineDate: '2024-12-10',
+  pipelineDate: '2025-01-20',
   addressablesIndex: 'addressables',
   articlesIndex: 'articles',
   eventsIndex: 'events',

--- a/api/scripts/holiday_closure_test.ts
+++ b/api/scripts/holiday_closure_test.ts
@@ -69,7 +69,7 @@ const applyItemsApiDeepstoreLogic = (
 const run = async () => {
   const elasticClient = await getElasticClient({
     serviceName: 'api',
-    pipelineDate: '2024-12-10',
+    pipelineDate: '2025-01-20',
     hostEndpointAccess: 'public',
   });
 

--- a/pipeline/src/local.ts
+++ b/pipeline/src/local.ts
@@ -23,7 +23,7 @@ const windowEvent: WindowEvent = {
 };
 
 getElasticClient({
-  pipelineDate: '2024-12-10',
+  pipelineDate: '2025-01-20',
   serviceName: 'pipeline',
   hostEndpointAccess: 'public',
 }).then(elasticClient => {

--- a/unpublisher/src/local.ts
+++ b/unpublisher/src/local.ts
@@ -10,7 +10,7 @@ import { createHandler } from './handler';
 const [_1, _2, ...deletionIds] = argv;
 
 getElasticClient({
-  pipelineDate: '2024-12-10',
+  pipelineDate: '2025-01-20',
   serviceName: 'unpublisher',
   hostEndpointAccess: 'public',
 }).then(async elasticClient => {


### PR DESCRIPTION
## What does this change?

Move everything over to using the new pipeline (for #123)

## How to test

Unsure for the live pipeline, but you could run it locally and test out reindexes etc.

## How can we measure success?

New events relevancy parameters are live

## Have we considered potential risks?
Well I haven't really done this before so that's a risk, but a chance to amend the README for next time 😄 