### PR TITLE
Update README on how to delete a pipeline and remove old pipeline module

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -37,5 +37,9 @@ Once you're happy and want it to become the main pipeline, change the value of `
 ## Deleting pipeline
 
 1. Make sure the old pipeline is not used by the API [by consulting the /\_elasticConfig endpoint](http://api.wellcomecollection.org/content/v0/_elasticConfig).
-2. Run a targeted destroy on the old pipeline: `terraform destroy -target module.[name]`
-3. Remove matching module from `pipeline.tf`
+2. Run a targeted destroy on the old pipeline using the `run_terraform` script:
+   `./run_terraform.sh destroy -target module.[name]`.
+   Changes should only relate to the named pipeline, check that before you apply.
+3. Changes will take a long time to apply, think over 20 mins. Let it run. Once it's done, you can check in AWS Lambdas that it's been removed, same for Elastic Cloud.
+4. Remove matching module from `pipeline.tf`. If you run `terraform plan`, you should get `"No changes. Your infrastructure matches the configuration."`.
+5. Make a PR for the module removal to ensure `main` is up-to-date.

--- a/infrastructure/pipeline.tf
+++ b/infrastructure/pipeline.tf
@@ -1,16 +1,3 @@
-module "pipeline_2024-12-10" {
-  source = "./pipeline_stack"
-
-  pipeline_date           = "2024-12-10"
-  window_duration_minutes = 15
-  deployment_template_id  = "aws-storage-optimized"
-  logging_cluster_id      = local.logging_cluster_id
-  network_config          = local.network_config
-  lambda_alarm_topic_arn  = local.catalogue_lambda_alarn_topic_arn
-
-  unpublish_event_rule = module.webhook.unpublish_event_rule
-}
-
 module "pipeline_2025-01-20" {
   source = "./pipeline_stack"
 


### PR DESCRIPTION
## What does this change?

#201 

Removes the old pipeline as the API [uses the new one](https://api.wellcomecollection.org/content/v0/_elasticConfig) since Friday and no problems have come up.

I've already destroyed the old pipeline with a targeted destroy so this just ensure `main` is up-to-date, as well as updates the README instructions based on what I ran into when doing this work!

## How to test
Does the README make sense? 
Does running `terraform plan` flag any changes?

## How can we measure success?

We now have everything we need to create/destroy pipelines on our own next time.

## Have we considered potential risks?

N/A already applied