### PR TITLE
Update ports to use local nginx for dev

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "NODE_ENV=production tsx ./server.ts",
-    "dev": "AWS_PROFILE=catalogue-developer NODE_ENV=development nodemon - exec 'tsx' ./server.ts",
+    "dev": "AWS_PROFILE=catalogue-developer PORT=3002 NODE_ENV=development nodemon - exec 'tsx' ./server.ts",
     "test": "jest",
     "check_holiday_closures": "AWS_PROFILE=catalogue-developer tsx ./scripts/holiday_closure_test.ts"
   },


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/wellcomecollection.org/pull/11551

This change updates the port that content API uses when run locally in order that it can run at the same time locally to enable a more complete local development experience when working with https://github.com/wellcomecollection/wellcomecollection.org

## How to test

- In the `./api` folder run:
  - `yarn && yarn dev`

The content API should be available on `localhost:3002`.

This change can be more thoroughly tested by reviewing https://github.com/wellcomecollection/wellcomecollection.org/pull/11551 and following the relevant steps described running this branch.

## How can we measure success?

Easier development!

## Have we considered potential risks?
This should have minimal impact as there are no prod changes, and the correct port is flagged to devs when the app starts.