### PR TITLE
Align filters names for events and articles

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  LIVE_PIPELINE: '2025-01-20'
+  LIVE_PIPELINE: '2025-02-06'
 steps:
   - label: 'autoformat'
     command: '.buildkite/scripts/autoformat.sh'

--- a/api/config.ts
+++ b/api/config.ts
@@ -12,7 +12,7 @@ const environment = environmentSchema.parse(process.env);
 // This configuration is exposed via the public healthcheck endpoint,
 // so be careful not to expose any secrets here.
 const config = {
-  pipelineDate: '2025-01-20',
+  pipelineDate: '2025-02-06',
   addressablesIndex: 'addressables',
   articlesIndex: 'articles',
   eventsIndex: 'events',

--- a/api/scripts/holiday_closure_test.ts
+++ b/api/scripts/holiday_closure_test.ts
@@ -69,7 +69,7 @@ const applyItemsApiDeepstoreLogic = (
 const run = async () => {
   const elasticClient = await getElasticClient({
     serviceName: 'api',
-    pipelineDate: '2025-01-20',
+    pipelineDate: '2025-02-06',
     hostEndpointAccess: 'public',
   });
 

--- a/api/src/queries/articles.ts
+++ b/api/src/queries/articles.ts
@@ -29,7 +29,7 @@ export const articlesFilter = {
     values: contributors,
     esQuery: {
       terms: {
-        'filter.contributorIds': contributors,
+        'filter.contributors': contributors,
       },
     },
   }),
@@ -37,7 +37,7 @@ export const articlesFilter = {
     values: formats,
     esQuery: {
       terms: {
-        'filter.formatId': formats,
+        'filter.format': formats,
       },
     },
   }),

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -26,7 +26,7 @@ export const eventsFilter = {
     values: formats,
     esQuery: {
       terms: {
-        'filter.formatId': formats,
+        'filter.format': formats,
       },
     },
   }),
@@ -34,7 +34,7 @@ export const eventsFilter = {
     values: interpretations,
     esQuery: {
       terms: {
-        'filter.interpretationIds': interpretations,
+        'filter.interpretations': interpretations,
       },
     },
   }),
@@ -42,7 +42,7 @@ export const eventsFilter = {
     values: audiences,
     esQuery: {
       terms: {
-        'filter.audienceIds': audiences,
+        'filter.audiences': audiences,
       },
     },
   }),
@@ -50,7 +50,7 @@ export const eventsFilter = {
     values: locations,
     esQuery: {
       terms: {
-        'filter.locationIds': locations,
+        'filter.locations': locations,
       },
     },
   }),

--- a/api/test/__snapshots__/query.test.ts.snap
+++ b/api/test/__snapshots__/query.test.ts.snap
@@ -185,7 +185,7 @@ exports[`events query makes the expected query to ES for a given set of query pa
           },
           "filter": {
             "terms": {
-              "filter.formatId": [
+              "filter.format": [
                 "test-format",
               ],
             },
@@ -203,7 +203,7 @@ exports[`events query makes the expected query to ES for a given set of query pa
           "filter": [
             {
               "terms": {
-                "filter.interpretationIds": [
+                "filter.interpretations": [
                   "test-interpretation",
                 ],
               },
@@ -227,7 +227,7 @@ exports[`events query makes the expected query to ES for a given set of query pa
           },
           "filter": {
             "terms": {
-              "filter.interpretationIds": [
+              "filter.interpretations": [
                 "test-interpretation",
               ],
             },
@@ -245,7 +245,7 @@ exports[`events query makes the expected query to ES for a given set of query pa
           "filter": [
             {
               "terms": {
-                "filter.formatId": [
+                "filter.format": [
                   "test-format",
                 ],
               },
@@ -262,14 +262,14 @@ exports[`events query makes the expected query to ES for a given set of query pa
       "filter": [
         {
           "terms": {
-            "filter.formatId": [
+            "filter.format": [
               "test-format",
             ],
           },
         },
         {
           "terms": {
-            "filter.interpretationIds": [
+            "filter.interpretations": [
               "test-interpretation",
             ],
           },

--- a/api/test/__snapshots__/query.test.ts.snap
+++ b/api/test/__snapshots__/query.test.ts.snap
@@ -21,7 +21,7 @@ exports[`articles query makes the expected query to ES for a given set of query 
           },
           "filter": {
             "terms": {
-              "filter.contributorIds": [
+              "filter.contributors": [
                 "test-contributor",
               ],
             },
@@ -39,7 +39,7 @@ exports[`articles query makes the expected query to ES for a given set of query 
           "filter": [
             {
               "terms": {
-                "filter.formatId": [
+                "filter.format": [
                   "test-format",
                 ],
               },
@@ -63,7 +63,7 @@ exports[`articles query makes the expected query to ES for a given set of query 
           },
           "filter": {
             "terms": {
-              "filter.formatId": [
+              "filter.format": [
                 "test-format",
               ],
             },
@@ -81,7 +81,7 @@ exports[`articles query makes the expected query to ES for a given set of query 
           "filter": [
             {
               "terms": {
-                "filter.contributorIds": [
+                "filter.contributors": [
                   "test-contributor",
                 ],
               },
@@ -98,14 +98,14 @@ exports[`articles query makes the expected query to ES for a given set of query 
       "filter": [
         {
           "terms": {
-            "filter.contributorIds": [
+            "filter.contributors": [
               "test-contributor",
             ],
           },
         },
         {
           "terms": {
-            "filter.formatId": [
+            "filter.format": [
               "test-format",
             ],
           },

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -19,7 +19,7 @@ From the project root, run command lines from the `publish: pipeline & unpublish
 3. Now upload them to S3:
 
    - `./.buildkite/scripts/upload_lambda_package.sh content-pipeline-[NEW-PIPELINE-DATE] ./pipeline/package.zip`.
-   - `./.buildkite/scripts/upload_lambda_package.sh content-unpublisher-[NEW-PIPELINE-DATE] ./pipeline/package.zip`.
+   - `./.buildkite/scripts/upload_lambda_package.sh content-unpublisher-[NEW-PIPELINE-DATE] ./unpublisher/package.zip`.
    - You should now be able to see those zip files in S3.
 
 4. Then, you could either go the Lambda service and manually upload them from S3, or use the script we have for it. If so, follow the command lines from `deploy: live pipeline & unpublisher` in `pipeline.yml`:

--- a/pipeline/src/indices/articles.ts
+++ b/pipeline/src/indices/articles.ts
@@ -134,10 +134,10 @@ export const mappings = {
     },
     filter: {
       properties: {
-        contributorIds: {
+        contributors: {
           type: 'keyword',
         },
-        formatId: {
+        format: {
           type: 'keyword',
         },
         publicationDate: {

--- a/pipeline/src/indices/events.ts
+++ b/pipeline/src/indices/events.ts
@@ -135,13 +135,13 @@ export const mappings = {
         formatId: {
           type: 'keyword',
         },
-        interpretationIds: {
+        interpretations: {
           type: 'keyword',
         },
-        audienceIds: {
+        audiences: {
           type: 'keyword',
         },
-        locationIds: {
+        locations: {
           type: 'keyword',
         },
         isAvailableOnline: {

--- a/pipeline/src/indices/events.ts
+++ b/pipeline/src/indices/events.ts
@@ -132,7 +132,7 @@ export const mappings = {
     },
     filter: {
       properties: {
-        formatId: {
+        format: {
           type: 'keyword',
         },
         interpretations: {

--- a/pipeline/src/local.ts
+++ b/pipeline/src/local.ts
@@ -23,7 +23,7 @@ const windowEvent: WindowEvent = {
 };
 
 getElasticClient({
-  pipelineDate: '2025-01-20',
+  pipelineDate: '2025-02-06',
   serviceName: 'pipeline',
   hostEndpointAccess: 'public',
 }).then(elasticClient => {

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -155,8 +155,8 @@ export const transformArticle = (
         series,
       },
       filter: {
-        contributorIds: flatContributors.map(c => c.id),
-        formatId: format.id,
+        contributors: flatContributors.map(c => c.id),
+        format: format.id,
         publicationDate: new Date(datePublished),
       },
       aggregatableValues: {

--- a/pipeline/src/transformers/eventDocument.ts
+++ b/pipeline/src/transformers/eventDocument.ts
@@ -202,10 +202,10 @@ export const transformEventDocument = (
         },
       },
       filter: {
-        formatId: format.id,
-        interpretationIds: interpretations.map(i => i.id),
-        audienceIds: audiences.map(a => a.id),
-        locationIds: locations.attendance.map(l => l.id),
+        format: format.id,
+        interpretations: interpretations.map(i => i.id),
+        audiences: audiences.map(a => a.id),
+        locations: locations.attendance.map(l => l.id),
         isAvailableOnline,
       },
       aggregatableValues: {

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -85,10 +85,10 @@ export type ElasticsearchEventDocument = {
     times: { startDateTime: Date[] };
   };
   filter: {
-    formatId: string;
-    interpretationIds: string[];
-    audienceIds: string[];
-    locationIds: string[];
+    format: string;
+    interpretations: string[];
+    audiences: string[];
+    locations: string[];
     isAvailableOnline: boolean;
   };
   aggregatableValues: {

--- a/pipeline/src/types/transformed/index.ts
+++ b/pipeline/src/types/transformed/index.ts
@@ -61,8 +61,8 @@ export type ElasticsearchArticle = {
   };
   filter: {
     publicationDate: Date;
-    contributorIds: string[];
-    formatId: string;
+    contributors: string[];
+    format: string;
   };
   aggregatableValues: {
     contributors: string[];

--- a/pipeline/test/transformers/__snapshots__/article.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/article.test.ts.snap
@@ -104,10 +104,10 @@ exports[`article transformer also works for webcomics (document: webcomics/XK9p2
       "uid": "groan",
     },
     "filter": {
-      "contributorIds": [
+      "contributors": [
         "WSQ9rygAAA9xtwfy",
       ],
-      "formatId": "W7d_ghAAALWY3Ujc",
+      "format": "W7d_ghAAALWY3Ujc",
       "publicationDate": 2019-04-12T09:00:00.000Z,
     },
     "id": "XK9p2RIAAO1vQn__",
@@ -243,10 +243,10 @@ exports[`article transformer also works for webcomics (document: webcomics/XUGru
       "uid": "footpath",
     },
     "filter": {
-      "contributorIds": [
+      "contributors": [
         "WSQ9rygAAA9xtwfy",
       ],
-      "formatId": "W7d_ghAAALWY3Ujc",
+      "format": "W7d_ghAAALWY3Ujc",
       "publicationDate": 2019-08-02T09:00:00.000Z,
     },
     "id": "XUGruhEAACYASyJh",
@@ -378,10 +378,10 @@ exports[`article transformer transforms articles from Prismic to the expected fo
       "uid": "ken-s-ten--looking-back-at-ten-years-of-wellcome-collection",
     },
     "filter": {
-      "contributorIds": [
+      "contributors": [
         "WXoU9yoAADqyj5ft",
       ],
-      "formatId": "W7TfJRAAAJ1D0eLK",
+      "format": "W7TfJRAAAJ1D0eLK",
       "publicationDate": 2017-08-07T23:00:01.000Z,
     },
     "id": "WXInvioAABlsbLHu",
@@ -514,8 +514,8 @@ exports[`article transformer transforms articles from Prismic to the expected fo
       "uid": "the-key-to-memory--follow-your-nose",
     },
     "filter": {
-      "contributorIds": [],
-      "formatId": "W7TfJRAAAJ1D0eLK",
+      "contributors": [],
+      "format": "W7TfJRAAAJ1D0eLK",
       "publicationDate": 2017-10-11T08:30:00.000Z,
     },
     "id": "WcvPmSsAAG5B5-ox",
@@ -704,11 +704,11 @@ exports[`article transformer transforms articles from Prismic to the expected fo
       "uid": "tracing-the-roots-of-our-fears-and-fixations",
     },
     "filter": {
-      "contributorIds": [
+      "contributors": [
         "YvtXgxAAACMA9j5d",
         "Yz07IxEAAA__s9BR",
       ],
-      "formatId": "W8CbPhEAAB8Nq4aG",
+      "format": "W8CbPhEAAB8Nq4aG",
       "publicationDate": 2022-10-18T09:00:00.000Z,
     },
     "id": "Y0U4GBEAAA__16h6",
@@ -880,10 +880,10 @@ exports[`article transformer transforms articles from Prismic to the expected fo
       "uid": "the-enigma-of-the-medieval-folding-almanac",
     },
     "filter": {
-      "contributorIds": [
+      "contributors": [
         "W3KvwikAACIAEFVE",
       ],
-      "formatId": "W7TfJRAAAJ1D0eLK",
+      "format": "W7TfJRAAAJ1D0eLK",
       "publicationDate": 2022-01-10T10:59:43.000Z,
     },
     "id": "YbjAThEAACEAcPYF",

--- a/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/eventDocument.test.ts.snap
@@ -140,11 +140,11 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "land-body-ecologies-festival-day-two",
     },
     "filter": {
-      "audienceIds": [],
-      "formatId": "W5fV5iYAACQAMxHb",
-      "interpretationIds": [],
+      "audiences": [],
+      "format": "W5fV5iYAACQAMxHb",
+      "interpretations": [],
       "isAvailableOnline": false,
-      "locationIds": [
+      "locations": [
         "online",
         "in-our-building",
       ],
@@ -332,13 +332,13 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "perspective-tour-with-jess-dobkin",
     },
     "filter": {
-      "audienceIds": [],
-      "formatId": "WmYRpCQAACUAn-Ap",
-      "interpretationIds": [
+      "audiences": [],
+      "format": "WmYRpCQAACUAn-Ap",
+      "interpretations": [
         "XkFGqxEAACIAIhNH",
       ],
       "isAvailableOnline": false,
-      "locationIds": [
+      "locations": [
         "in-our-building",
       ],
     },
@@ -495,11 +495,11 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "lights-up-on-the-cult-of-beauty-11",
     },
     "filter": {
-      "audienceIds": [],
-      "formatId": "dfc2b7f9-c362-47da-9644-b0f98212ccaa",
-      "interpretationIds": [],
+      "audiences": [],
+      "format": "dfc2b7f9-c362-47da-9644-b0f98212ccaa",
+      "interpretations": [],
       "isAvailableOnline": false,
-      "locationIds": [
+      "locations": [
         "in-our-building",
       ],
     },
@@ -681,16 +681,16 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "standards--my-right-to-beauty",
     },
     "filter": {
-      "audienceIds": [
+      "audiences": [
         "WlYWECQAACcAWdBf",
       ],
-      "formatId": "Wn3Q3SoAACsAIeFI",
-      "interpretationIds": [
+      "format": "Wn3Q3SoAACsAIeFI",
+      "interpretations": [
         "XkFGqxEAACIAIhNH",
         "W5JXVSYAACYAGtkh",
       ],
       "isAvailableOnline": false,
-      "locationIds": [
+      "locations": [
         "in-our-building",
       ],
     },
@@ -853,13 +853,13 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "recipes-for-early-modern-beauty",
     },
     "filter": {
-      "audienceIds": [],
-      "formatId": "Wd-QYCcAACcAoiJS",
-      "interpretationIds": [
+      "audiences": [],
+      "format": "Wd-QYCcAACcAoiJS",
+      "interpretations": [
         "X2jPiRMAACIA8Vzo",
       ],
       "isAvailableOnline": true,
-      "locationIds": [
+      "locations": [
         "online",
       ],
     },
@@ -1019,11 +1019,11 @@ exports[`eventDocument transformer transforms events from Prismic to the expecte
       "uid": "sexing-up-the-internet",
     },
     "filter": {
-      "audienceIds": [],
-      "formatId": "WcKmiysAACx_A8NR",
-      "interpretationIds": [],
+      "audiences": [],
+      "format": "WcKmiysAACx_A8NR",
+      "interpretations": [],
       "isAvailableOnline": false,
-      "locationIds": [
+      "locations": [
         "in-our-building",
       ],
     },

--- a/unpublisher/src/local.ts
+++ b/unpublisher/src/local.ts
@@ -10,7 +10,7 @@ import { createHandler } from './handler';
 const [_1, _2, ...deletionIds] = argv;
 
 getElasticClient({
-  pipelineDate: '2025-01-20',
+  pipelineDate: '2025-02-06',
   serviceName: 'unpublisher',
   hostEndpointAccess: 'public',
 }).then(async elasticClient => {


### PR DESCRIPTION
> [!WARNING]
> DO NOT MERGE THIS UNTIL WE ARE READY TO GO AHEAD WITH THE NEW PIPELINE.
> This changes the mapping and the transformer, which won't work with the current pipeline.

Added Paul as a reviewer as he's the consultant on the work; but @wellcomecollection/digital-experience approval will be necessary too ✨ 

## What does this change?

#121 
Removes the notion of "Ids" in filter names
See ticket for more information, [starting at this comment](https://github.com/wellcomecollection/content-api/issues/121#issuecomment-2633614082).

## How to test

If you run it locally, passing in query params, does the API still return the same thing as production?

## How can we measure success?

Aligned with our principles and better to be built upon.

## Have we considered potential risks?
It breaks search! But we'll be able to test this locally and in staging first.
