### PR TITLE
Add pipeline `2025-02-26` , creation script and modify README

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -3,37 +3,12 @@
 ## Creating pipeline
 
 1. Add new module to `pipeline.tf`, named with the date.
-2. From `./infrastructure`, plan and apply Terraform (`terraform init` might be required first)
-
-At this stage you could chose to do it manually (see instructions below), or run `./create_pipeline.sh`. If you chose to do so, make sure you run it with its required arguments; `./create_pipeline.sh PIPELINE_DATE=[NEW PIPELINE DATE] AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev`.
-
+2. From `./infrastructure`, plan and apply Terraform (`./run_terraform.sh plan`), although `terraform init` will probably be required first.
 3. Now your pipeline should have been created, you may confirm so by going into AWS Lambdas as well as ElasticCloud and seeing that it's there.
+4. Run `./create_pipeline.sh [NEW PIPELINE DATE]`.
+5. The Elasticsearch indexes will have been created and configured, but you'll need to run a reindex manually. The scheduler will be set but only considers the last 15 minutes of documents being published, so the inital run has to be manual (although it could be made to be automated should we desire it). Before you reindex, **_remember to change `pipelineDate` values locally to match your new pipeline's._**, otherwise you'll be doing those in the live pipeline.
 
-You need to actually fill the Lambdas with your code. For all the steps below, **MAKE SURE YOU ARE SPECIFYING THE NEW PIPELINE'S NAME**, otherwise the default will apply to the live one.
-From the project root, run command lines from the `publish: pipeline & unpublisher ($LIVE_PIPELINE)` task in `.buildkite/pipeline.yml` locally, skipping `yarn install`:
-
-1. The first two lines are creating zips of the required packages, you can run them as is:
-   `yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package`
-
-2. As it's not running the command lines in Buildkite, you'll need to define a `$BUILDKITE_COMMIT` (could be anything, just needs to be defined. For example: `BUILDKITE_COMMIT=dev`) and `AWS_PROFILE=catalogue-developer` for the next commands.
-
-3. Now upload them to S3:
-
-   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/upload_lambda_package.sh content-pipeline-[NEW-PIPELINE-DATE] ./pipeline/package.zip`.
-   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/upload_lambda_package.sh content-unpublisher-[NEW-PIPELINE-DATE] ./unpublisher/package.zip`.
-   - You should now be able to see those zip files in S3.
-
-4. Then, you could either go the Lambda service and manually upload them from S3, or use the script we have for it. If so, follow the command lines from `deploy: live pipeline & unpublisher` in `pipeline.yml`:
-
-   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/deploy_lambda.sh content-pipeline-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
-   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/deploy_lambda.sh content-unpublisher-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
-   - Your Lambdas should now have the correct code uploaded in them.
-
-5. The Elasticsearch indexes will have been created and configured, but you'll need to index them manually. The scheduler will be set but only considers the last 15 minutes of documents being published, so the inital run has to be manual (we could automate that in a different piece of work).
-
-To deploy any work locally (e.g. `reindex`), **_remember to change `pipelineDate` values locally to match your new pipeline's._**. Otherwise you'll be doing those in the live pipeline.
-
-Once you're happy and want it to become the main pipeline, change the value of `LIVE_PIPELINE` in `.buildkite/pipeline.yml` to match the new one. Also ensure that all `pipelineDate` values match the new one.
+Once you're happy and want it to become the main pipeline, change the value of `LIVE_PIPELINE` in `.buildkite/pipeline.yml` to match the new one. Double check that all `pipelineDate` values match the new one.
 
 ## Deleting pipeline
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -4,28 +4,29 @@
 
 1. Add new module to `pipeline.tf`, named with the date.
 2. From `./infrastructure`, plan and apply Terraform (`terraform init` might be required first)
+
+At this stage you could chose to do it manually (see instructions below), or run `./create_pipeline.sh`. If you chose to do so, make sure you run it with its required arguments; `./create_pipeline.sh PIPELINE_DATE=[NEW PIPELINE DATE] AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev`.
+
 3. Now your pipeline should have been created, you may confirm so by going into AWS Lambdas as well as ElasticCloud and seeing that it's there.
 
 You need to actually fill the Lambdas with your code. For all the steps below, **MAKE SURE YOU ARE SPECIFYING THE NEW PIPELINE'S NAME**, otherwise the default will apply to the live one.
 From the project root, run command lines from the `publish: pipeline & unpublisher ($LIVE_PIPELINE)` task in `.buildkite/pipeline.yml` locally, skipping `yarn install`:
 
-1. The first two lines are creating zips of the required packages, you can run them as is.
+1. The first two lines are creating zips of the required packages, you can run them as is:
+   `yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package`
 
-2. As it's not running the command lines in Buildkite, you'll need to define a `$BUILDKITE_COMMIT` and the correct `AWS_PROFILE` for the next commands:
-
-   - `BUILDKITE_COMMIT=dev` (could be anything, just needs to be defined)
-   - `AWS_PROFILE=catalogue-developer`
+2. As it's not running the command lines in Buildkite, you'll need to define a `$BUILDKITE_COMMIT` (could be anything, just needs to be defined. For example: `BUILDKITE_COMMIT=dev`) and `AWS_PROFILE=catalogue-developer` for the next commands.
 
 3. Now upload them to S3:
 
-   - `./.buildkite/scripts/upload_lambda_package.sh content-pipeline-[NEW-PIPELINE-DATE] ./pipeline/package.zip`.
-   - `./.buildkite/scripts/upload_lambda_package.sh content-unpublisher-[NEW-PIPELINE-DATE] ./unpublisher/package.zip`.
+   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/upload_lambda_package.sh content-pipeline-[NEW-PIPELINE-DATE] ./pipeline/package.zip`.
+   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/upload_lambda_package.sh content-unpublisher-[NEW-PIPELINE-DATE] ./unpublisher/package.zip`.
    - You should now be able to see those zip files in S3.
 
 4. Then, you could either go the Lambda service and manually upload them from S3, or use the script we have for it. If so, follow the command lines from `deploy: live pipeline & unpublisher` in `pipeline.yml`:
 
-   - `.buildkite/scripts/deploy_lambda.sh content-pipeline-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
-   - `.buildkite/scripts/deploy_lambda.sh content-unpublisher-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
+   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/deploy_lambda.sh content-pipeline-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
+   - `AWS_PROFILE=catalogue-developer BUILDKITE_COMMIT=dev .buildkite/scripts/deploy_lambda.sh content-unpublisher-[NEW-PIPELINE-DATE] ref.$BUILDKITE_COMMIT`
    - Your Lambdas should now have the correct code uploaded in them.
 
 5. The Elasticsearch indexes will have been created and configured, but you'll need to index them manually. The scheduler will be set but only considers the last 15 minutes of documents being published, so the inital run has to be manual (we could automate that in a different piece of work).

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -1,31 +1,35 @@
 #!/usr/bin/env bash
 
-echo Assign variables
-for ARGUMENT in "$@"
-do
-   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+# Ensure the script will exit if any of the commands in it fail.
+set -o errexit
 
-   KEY_LENGTH=${#KEY}
-   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+# Set up env vars for this script
+PIPELINE_DATE="$1"
+export AWS_PROFILE=catalogue-developer
+export BUILDKITE_COMMIT=dev
+export AWS_PAGER="" # Turn off pager for AWS CLI
 
-   export "$KEY"="$VALUE"
-done
+# This returns the path to the root of the repo, used later
+ROOT=$(git rev-parse --show-toplevel)
 
-echo Ensure all necessary variables have been declared
-if [[ -z $PIPELINE_DATE || -z $AWS_PROFILE || -z $BUILDKITE_COMMIT ]]; then
-  echo "ERROR: PIPELINE_DATE, BUILDKITE_COMMIT and AWS_PROFILE are mandatory arguments.";
-  exit 1;
+# If no pipeline specified, tell the user how to use the script
+if [[ -z $PIPELINE_DATE ]]; then
+  echo "Usage: ./create_pipeline.sh <PIPELINE_DATE>"
+  exit 1
 fi
+
+# Ensure there are no unset variables from this point on
+set -o nounset
 
 echo "Creating zips for packages ..."
 yarn workspace @weco/content-pipeline run package && \
 yarn workspace @weco/content-unpublisher run package
 
 echo "Uploading zips to S3 ..."
-bash ../.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE ../pipeline/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
-bash ../.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE ../unpublisher/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
+$ROOT/.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE $ROOT/pipeline/package.zip
+$ROOT/.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE $ROOT/unpublisher/package.zip
 
 echo "Downloading zips from S3 and deploying Lambdas ..."
-bash ../.buildkite/scripts/deploy_lambda.sh content-pipeline-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
-bash ../.buildkite/scripts/deploy_lambda.sh content-unpublisher-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
+$ROOT/.buildkite/scripts/deploy_lambda.sh content-pipeline-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
+$ROOT/.buildkite/scripts/deploy_lambda.sh content-unpublisher-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
 

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -18,7 +18,8 @@ if [[ -z $PIPELINE_DATE || -z $AWS_PROFILE || -z $BUILDKITE_COMMIT ]]; then
 fi
 
 echo "Creating zips for packages ..."
-yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package
+yarn workspace @weco/content-pipeline run package && \
+yarn workspace @weco/content-unpublisher run package
 
 echo "Uploading zips to S3 ..."
 bash ../.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE ../pipeline/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -21,15 +21,18 @@ fi
 # Ensure there are no unset variables from this point on
 set -o nounset
 
-echo "Creating zips for packages ..."
+# Command lines from `publish: pipeline & unpublisher ($LIVE_PIPELINE)` in `.buildkite/pipeline.yml`.
+echo "Creating zips for required packages ..."
 yarn workspace @weco/content-pipeline run package && \
 yarn workspace @weco/content-unpublisher run package
 
 echo "Uploading zips to S3 ..."
 $ROOT/.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE $ROOT/pipeline/package.zip
 $ROOT/.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE $ROOT/unpublisher/package.zip
+echo "Zips successfully uploaded to S3."
 
+#  Command lines from `deploy: live pipeline & unpublisher` in `.buildkite/pipeline.yml`:
 echo "Downloading zips from S3 and deploying Lambdas ..."
 $ROOT/.buildkite/scripts/deploy_lambda.sh content-pipeline-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
 $ROOT/.buildkite/scripts/deploy_lambda.sh content-unpublisher-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
-
+echo "Packages deployed to Lambdas ..."

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -20,7 +20,7 @@ fi
 echo "Creating zips for packages ..."
 yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package
 
-echo Upload zips to S3
+echo "Uploading zips to S3 ..."
 bash ../.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE ../pipeline/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
 bash ../.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE ../unpublisher/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
 

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -17,7 +17,7 @@ if [[ -z $PIPELINE_DATE || -z $AWS_PROFILE || -z $BUILDKITE_COMMIT ]]; then
   exit 1;
 fi
 
-echo Create zips for packages
+echo "Creating zips for packages ..."
 yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package
 
 echo Upload zips to S3

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+echo Assign variables
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+echo Ensure all necessary variables have been declared
+if [[ -z $PIPELINE_DATE || -z $AWS_PROFILE || -z $BUILDKITE_COMMIT ]]; then
+  echo "ERROR: PIPELINE_DATE, BUILDKITE_COMMIT and AWS_PROFILE are mandatory arguments.";
+  exit 1;
+fi
+
+echo Create zips for packages
+yarn workspace @weco/content-pipeline run package && yarn workspace @weco/content-unpublisher run package
+
+echo Upload zips to S3
+bash ../.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE ../pipeline/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
+bash ../.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE ../unpublisher/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
+
+echo Get zips in S3 and deploy them to our Lambdas
+bash ../.buildkite/scripts/deploy_lambda.sh content-pipeline-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
+bash ../.buildkite/scripts/deploy_lambda.sh content-unpublisher-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
+

--- a/infrastructure/create_pipeline.sh
+++ b/infrastructure/create_pipeline.sh
@@ -24,7 +24,7 @@ echo "Uploading zips to S3 ..."
 bash ../.buildkite/scripts/upload_lambda_package.sh content-pipeline-$PIPELINE_DATE ../pipeline/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
 bash ../.buildkite/scripts/upload_lambda_package.sh content-unpublisher-$PIPELINE_DATE ../unpublisher/package.zip $AWS_PROFILE=$AWS_PROFILE $BUILDKITE_COMMIT=$BUILDKITE_COMMIT
 
-echo Get zips in S3 and deploy them to our Lambdas
+echo "Downloading zips from S3 and deploying Lambdas ..."
 bash ../.buildkite/scripts/deploy_lambda.sh content-pipeline-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
 bash ../.buildkite/scripts/deploy_lambda.sh content-unpublisher-$PIPELINE_DATE ref.$BUILDKITE_COMMIT
 

--- a/infrastructure/pipeline.tf
+++ b/infrastructure/pipeline.tf
@@ -9,3 +9,15 @@ module "pipeline_2025-02-17" {
 
   unpublish_event_rule = module.webhook.unpublish_event_rule
 }
+
+module "pipeline_2025-02-26" {
+  source                  = "./pipeline_stack"
+  pipeline_date           = "2025-02-26"
+  window_duration_minutes = 15
+  deployment_template_id  = "aws-storage-optimized"
+  logging_cluster_id      = local.logging_cluster_id
+  network_config          = local.network_config
+  lambda_alarm_topic_arn  = local.catalogue_lambda_alarn_topic_arn
+
+  unpublish_event_rule = module.webhook.unpublish_event_rule
+}


### PR DESCRIPTION
## What does this change?

The README instructions weren't 100% working (couldn't set required variables and then run scripts, they had to be declared every time). So I also created a bash script to create pipelines and removed the instructions from the README.

Basically I don't really know what I'm doing with this, it's my first time! I tried to put in some validation, but I'd welcome any improvement suggestions/corrections/telling off about it! Thank you!

## How to test

Create a new pipeline I guess? I've run it locally and it does the job, happy to help with the reviewing/testing process.

## How can we measure success?

Easier/faster to create new pipelines.

## Have we considered potential risks?
Again it's my first time with this, so potentially there are risks, yes.