### PR TITLE
Timespan aggregation

### DIFF
--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -18,6 +18,7 @@ import { ResultList } from '@weco/content-api/src/types/responses';
 
 import { HttpError } from './error';
 import { paginationElasticBody, PaginationQueryParameters } from './pagination';
+import { timespans } from './utils';
 import { queryValidator } from './validation';
 
 type QueryParams = {
@@ -34,35 +35,6 @@ type QueryParams = {
 } & PaginationQueryParameters;
 
 type EventsHandler = RequestHandler<never, ResultList, never, QueryParams>;
-
-export const MONTHS = [
-  'january',
-  'february',
-  'march',
-  'april',
-  'may',
-  'june',
-  'july',
-  'august',
-  'september',
-  'october',
-  'november',
-  'december',
-] as const;
-const timespans = [
-  'today',
-  'this-week',
-  'this-weekend',
-  'this-month',
-  'future',
-  'past',
-  ...MONTHS,
-] as const;
-export type Timespan = (typeof timespans)[number];
-export function isValidTimespan(type?: string | string[]): type is Timespan {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return timespans.includes(type as any);
-}
 
 const sortValidator = queryValidator({
   name: 'sort',

--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -36,42 +36,6 @@ type QueryParams = {
 
 type EventsHandler = RequestHandler<never, ResultList, never, QueryParams>;
 
-const sortValidator = queryValidator({
-  name: 'sort',
-  defaultValue: 'relevance',
-  allowed: ['relevance', 'times.startDateTime'],
-  singleValue: true,
-});
-
-const sortOrderValidator = queryValidator({
-  name: 'sortOrder',
-  defaultValue: 'desc',
-  allowed: ['asc', 'desc'],
-  singleValue: true,
-});
-
-const aggregationsValidator = queryValidator({
-  name: 'aggregations',
-  allowed: [
-    'format',
-    'audience',
-    'interpretation',
-    'location',
-    'isAvailableOnline',
-  ],
-});
-
-const locationsValidator = queryValidator({
-  name: 'location',
-  allowed: ['online', 'in-our-building'],
-});
-
-const isAvailableOnlineValidator = queryValidator({
-  name: 'isAvailableOnline',
-  allowed: ['true'],
-  singleValue: true,
-});
-
 export const MONTHS = [
   'january',
   'february',
@@ -100,6 +64,43 @@ export function isValidTimespan(type?: string | string[]): type is Timespan {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return timespans.includes(type as any);
 }
+
+const sortValidator = queryValidator({
+  name: 'sort',
+  defaultValue: 'relevance',
+  allowed: ['relevance', 'times.startDateTime'],
+  singleValue: true,
+});
+
+const sortOrderValidator = queryValidator({
+  name: 'sortOrder',
+  defaultValue: 'desc',
+  allowed: ['asc', 'desc'],
+  singleValue: true,
+});
+
+const aggregationsValidator = queryValidator({
+  name: 'aggregations',
+  allowed: [
+    'format',
+    'audience',
+    'interpretation',
+    'location',
+    'isAvailableOnline',
+    'timespan',
+  ],
+});
+
+const locationsValidator = queryValidator({
+  name: 'location',
+  allowed: ['online', 'in-our-building'],
+});
+
+const isAvailableOnlineValidator = queryValidator({
+  name: 'isAvailableOnline',
+  allowed: ['true'],
+  singleValue: true,
+});
 
 const timespanValidator = queryValidator({
   name: 'timespan',

--- a/api/src/controllers/utils.ts
+++ b/api/src/controllers/utils.ts
@@ -1,7 +1,6 @@
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import { DateTime } from 'luxon';
 
-import { MONTHS, Timespan } from '@weco/content-api/src/controllers/events';
 import {
   DayOfWeek,
   ExceptionalClosedDay,
@@ -97,6 +96,35 @@ function setHourAndMinute(date: Date, time: string): string | undefined {
   });
   // time is set in London, we can now convert back to UTC ISO string
   return withHourAndMinute.toUTC().toISO() || undefined;
+}
+
+export const MONTHS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+] as const;
+export const timespans = [
+  'today',
+  'this-week',
+  'this-weekend',
+  'this-month',
+  'future',
+  'past',
+  ...MONTHS,
+] as const;
+export type Timespan = (typeof timespans)[number];
+export function isValidTimespan(type?: string): type is Timespan {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return timespans.includes(type as any);
 }
 
 export const getTimespanRange = (

--- a/api/src/helpers/responses.ts
+++ b/api/src/helpers/responses.ts
@@ -65,7 +65,7 @@ export const mapAggregations = (
             data: {
               type: 'EventTimespan',
               id: key,
-              label: String(key).charAt(0).toUpperCase() + String(key).slice(1),
+              label: `${String(key).charAt(0).toUpperCase() + String(key).slice(1)} events`,
             },
             count: aggregation.timespan[key].count_parent?.doc_count,
             type: 'AggregationBucket',

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -1,17 +1,28 @@
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 
-import { isValidTimespan } from '@weco/content-api/src/controllers/events';
-import { getTimespanRange } from '@weco/content-api/src/controllers/utils';
+import {
+  getTimespanRange,
+  isValidTimespan,
+} from '@weco/content-api/src/controllers/utils';
 
 import { TermsFilter } from './common';
 
-const getDateRange = (timespan?: string | string[]) => {
+const getDateRange = (
+  timespan?: string | string[]
+): QueryDslQueryContainer[] | undefined => {
   let queryRange;
 
-  if (timespan && isValidTimespan(timespan))
-    queryRange = getTimespanRange(timespan);
+  if (timespan) {
+    const isArray = Array.isArray(timespan);
 
-  return queryRange || undefined;
+    if (isArray && isValidTimespan(timespan[0]))
+      queryRange = getTimespanRange(timespan[0]);
+
+    if (!isArray && isValidTimespan(timespan))
+      queryRange = getTimespanRange(timespan);
+  }
+
+  return queryRange;
 };
 
 export const eventsQuery = (queryString: string): QueryDslQueryContainer => ({

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -122,9 +122,7 @@ export const eventsAggregations = {
     aggs: {
       all: {
         filter: {
-          bool: {
-            filter: [],
-          },
+          match_all: {},
         },
         aggs: {
           count_parent: {

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -115,8 +115,8 @@ export const eventsAggregations = {
   // https://github.com/wellcomecollection/content-api/issues/220
   timespan: {
     terms: {
-      size: 5,
-      field: 'filter.timespan', // use filter values and not create aggregations for it
+      size: 3,
+      field: 'filter.timespan',
     },
   },
 } as const;

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -111,12 +111,63 @@ export const eventsAggregations = {
       field: 'aggregatableValues.isAvailableOnline',
     },
   },
-  // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html
-  // https://github.com/wellcomecollection/content-api/issues/220
   timespan: {
-    terms: {
-      size: 3,
-      field: 'filter.timespan',
+    nested: {
+      path: 'filter.times',
+    },
+    aggs: {
+      all: {
+        filter: {
+          bool: {
+            filter: [],
+          },
+        },
+        aggs: {
+          count_parent: {
+            reverse_nested: {},
+          },
+        },
+      },
+      past: {
+        filter: {
+          bool: {
+            filter: [
+              {
+                range: {
+                  'filter.times.endDateTime': {
+                    lt: 'now',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        aggs: {
+          count_parent: {
+            reverse_nested: {},
+          },
+        },
+      },
+      future: {
+        filter: {
+          bool: {
+            filter: [
+              {
+                range: {
+                  'filter.times.endDateTime': {
+                    gt: 'now',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        aggs: {
+          count_parent: {
+            reverse_nested: {},
+          },
+        },
+      },
     },
   },
 } as const;

--- a/api/src/queries/events.ts
+++ b/api/src/queries/events.ts
@@ -5,7 +5,7 @@ import { getTimespanRange } from '@weco/content-api/src/controllers/utils';
 
 import { TermsFilter } from './common';
 
-const getDateRange = (timespan?: string) => {
+const getDateRange = (timespan?: string | string[]) => {
   let queryRange;
 
   if (timespan && isValidTimespan(timespan))
@@ -77,7 +77,7 @@ export const eventsFilter = {
       path: 'filter.times',
       query: {
         bool: {
-          must: getDateRange(timespan[0]), // TODO there is always just one so... this is a bit weird
+          must: getDateRange(timespan),
         },
       },
     },

--- a/api/src/queries/faceting.ts
+++ b/api/src/queries/faceting.ts
@@ -45,28 +45,55 @@ export const rewriteAggregationsForFacets = (
 ): Record<string, AggregationsAggregationContainer> =>
   Object.fromEntries(
     Object.entries(aggregations).map(([name, agg]) => {
-      const otherFilters = excludeValue(postFilters, name);
-      const filteredAgg: AggregationsAggregationContainer = {
-        filter: {
-          bool: {
-            filter: otherFilters.map(esQuery),
+      if (name !== 'timespan') {
+        const otherFilters = excludeValue(postFilters, name);
+        // TODO add timespan consideration??
+        const filteredAgg: AggregationsAggregationContainer = {
+          filter: {
+            bool: {
+              filter: otherFilters.map(esQuery),
+            },
           },
-        },
-        aggs: {
-          terms: agg,
-        },
-      };
-
-      if (name in postFilters) {
-        filteredAgg.aggs!.self_filter = {
-          filter: esQuery(postFilters[name]),
           aggs: {
-            terms: includeEmptyFilterValues(agg, postFilters[name]),
+            terms: agg,
           },
-        } as AggregationsAggregationContainer;
-      }
+        };
 
-      return [name, filteredAgg];
+        if (name in postFilters) {
+          filteredAgg.aggs!.self_filter = {
+            filter: esQuery(postFilters[name]),
+            aggs: {
+              terms: includeEmptyFilterValues(agg, postFilters[name]),
+            },
+          } as AggregationsAggregationContainer;
+        }
+
+        return [name, filteredAgg];
+      } else {
+        const otherFilters = excludeValue(postFilters, name);
+        const filteredAgg: AggregationsAggregationContainer = {
+          filter: {
+            bool: {
+              filter: otherFilters.map(esQuery),
+            },
+          },
+          aggs: {
+            timespan: agg,
+          },
+        };
+
+        // TODO ?
+        // if (name in postFilters) {
+        //   filteredAgg.aggs!.self_filter = {
+        //     filter: esQuery(postFilters[name]),
+        //     aggs: {
+        //       terms: includeEmptyFilterValues(agg, postFilters[name]),
+        //     },
+        //   } as AggregationsAggregationContainer;
+        // }
+
+        return [name, filteredAgg];
+      }
     })
   );
 

--- a/api/src/queries/faceting.ts
+++ b/api/src/queries/faceting.ts
@@ -45,6 +45,8 @@ export const rewriteAggregationsForFacets = (
 ): Record<string, AggregationsAggregationContainer> =>
   Object.fromEntries(
     Object.entries(aggregations).map(([name, agg]) => {
+      const isTimespan = name === 'timespan';
+
       const otherFilters = excludeValue(postFilters, name);
       const filteredAgg: AggregationsAggregationContainer = {
         filter: {
@@ -53,13 +55,12 @@ export const rewriteAggregationsForFacets = (
           },
         },
         aggs: {
-          ...(name !== 'timespan' && { terms: agg }),
-          ...(name === 'timespan' && { timespan: agg }),
+          ...(isTimespan ? { timespan: agg } : { terms: agg }),
         },
       };
 
       // We don't want timespan to self-filter as all of its options should always be visible.
-      if (name !== 'timespan') {
+      if (!isTimespan) {
         if (name in postFilters) {
           filteredAgg.aggs!.self_filter = {
             filter: esQuery(postFilters[name]),

--- a/api/test/__snapshots__/query.test.ts.snap
+++ b/api/test/__snapshots__/query.test.ts.snap
@@ -208,6 +208,24 @@ exports[`events query makes the expected query to ES for a given set of query pa
                 ],
               },
             },
+            {
+              "nested": {
+                "path": "filter.times",
+                "query": {
+                  "bool": {
+                    "must": [
+                      {
+                        "range": {
+                          "filter.times.endDateTime": {
+                            "lt": "now",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
           ],
         },
       },
@@ -250,6 +268,105 @@ exports[`events query makes the expected query to ES for a given set of query pa
                 ],
               },
             },
+            {
+              "nested": {
+                "path": "filter.times",
+                "query": {
+                  "bool": {
+                    "must": [
+                      {
+                        "range": {
+                          "filter.times.endDateTime": {
+                            "lt": "now",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    "timespan": {
+      "aggs": {
+        "timespan": {
+          "aggs": {
+            "all": {
+              "aggs": {
+                "count_parent": {
+                  "reverse_nested": {},
+                },
+              },
+              "filter": {
+                "match_all": {},
+              },
+            },
+            "future": {
+              "aggs": {
+                "count_parent": {
+                  "reverse_nested": {},
+                },
+              },
+              "filter": {
+                "bool": {
+                  "filter": [
+                    {
+                      "range": {
+                        "filter.times.endDateTime": {
+                          "gt": "now",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            "past": {
+              "aggs": {
+                "count_parent": {
+                  "reverse_nested": {},
+                },
+              },
+              "filter": {
+                "bool": {
+                  "filter": [
+                    {
+                      "range": {
+                        "filter.times.endDateTime": {
+                          "lt": "now",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          "nested": {
+            "path": "filter.times",
+          },
+        },
+      },
+      "filter": {
+        "bool": {
+          "filter": [
+            {
+              "terms": {
+                "filter.format": [
+                  "test-format",
+                ],
+              },
+            },
+            {
+              "terms": {
+                "filter.interpretations": [
+                  "test-interpretation",
+                ],
+              },
+            },
           ],
         },
       },
@@ -274,6 +391,24 @@ exports[`events query makes the expected query to ES for a given set of query pa
             ],
           },
         },
+        {
+          "nested": {
+            "path": "filter.times",
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "range": {
+                      "filter.times.endDateTime": {
+                        "lt": "now",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
       ],
     },
   },
@@ -296,22 +431,6 @@ exports[`events query makes the expected query to ES for a given set of query pa
           "operator": "or",
           "query": "henry wellcome",
           "type": "cross_fields",
-        },
-        "nested": {
-          "path": "filter.times",
-          "query": {
-            "bool": {
-              "must": [
-                {
-                  "range": {
-                    "filter.times.endDateTime": {
-                      "lt": "now",
-                    },
-                  },
-                },
-              ],
-            },
-          },
         },
       },
       "must_not": {

--- a/api/test/query.test.ts
+++ b/api/test/query.test.ts
@@ -73,7 +73,7 @@ describe('events query', () => {
   // The purpose of this test is as a smoke test for the question,
   // "do we understand how we map a given query into an ES request?"
   it('makes the expected query to ES for a given set of query parameters', async () => {
-    const aggregations = 'format,interpretation';
+    const aggregations = 'format,interpretation,timespan';
     const format = 'test-format';
     const interpretation = 'test-interpretation';
     const pageSize = 20;


### PR DESCRIPTION
## What does this change?

#220 

Finding out that our code is extremely optimised/clever about reutilising transformers for all of our filters and aggregations, but since `timespan`/Date filter has very different requirements, adding it is very difficult. 

### Some context on decisions made
- The demand does seem to have been simplified from the original ticket demands as the only filters we will want are:
  1. All
  2. Past
  3. Future
  4. Current
     * Ignoring this one for now but might be good to keep in mind, we'll add it same time as exhibitions, I think next quarter. This is good to not as it'll compare the start AND end date, whereas the other ones only care about the end date.

- This filter will be our first RADIO BUTTON filter; so **only one value will be passed/allowed at a time**.
- Events can have multiple dates, which is why we've mapped the `filter.times` field [as NESTED](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html), so the filtering made sense. 
  - Because an event could have multiple end dates, our query could match multiple dates within one document. This is why we use `reverse_nested` [in the aggregation](https://github.com/wellcomecollection/content-api/pull/236/files#diff-d0c3ac56951ef0bed6423da506a51524b707225f3e38a4228687e6830d6e9f05R165-R168), because we only want the number of **documents** that match and not the number of **dates**.
- FYI: Events with multiple dates can be returned both when filtered with Past and when filtered with Future as any of their dates might match either and it was a conscious call made by Lauren.


### Work so far (18/03)
[The aggregation query I added](https://github.com/wellcomecollection/content-api/pull/236/files#diff-d0c3ac56951ef0bed6423da506a51524b707225f3e38a4228687e6830d6e9f05) seems to be the correct one as it functions well in the Elasticsearch console. 

The aggregation query and its response not being shaped like every other filter query/response is where it gets messy (e.g. it doesn't have buckets as it's a filter aggregation)

According to our code, any new aggregation should;
- Take other filters into account
- Take `self_filter` into account
- Be taken into account by the other filters
This is done in [this helper function](https://github.com/wellcomecollection/content-api/pull/236/files#diff-5fd53a7634e25318abd217a9a2171f5abafd4cae08fd5f704757e3b3ba215f71), which I've started messing up to allow for the `timespan` shape/requirements.

I've also had to change the response's aggregations transformers, [where it maps all the aggregations together](https://github.com/wellcomecollection/content-api/blob/5b0f826f968acd8951332667e1a83f7dbd8c1a49/api/src/helpers/responses.ts#L34). I think we could put this to the side for later though. 

As can be seen in this PR, Typescript is mad at me for those changes and I'm not certain why.

### After chats with Paul and extra work (20/03)

I believe this is now working as expected and covers all grounds. I had to amend the `query` test (which was wrong anyway!) and address circular dependencies (thanks [madge](https://github.com/pahen/madge)!), which is why some helpers have been moved around.

The timespan filter/query is now removed from the general query and added in the aggregations objects instead.
We've made it so it did not self-filter as we don't want it to work that way.

## How to test

Run locally and make sure that this works as expected:
- Take other filters into account
- Does not self-filter
- Be taken into account by the other filters
 
[Example query filtered by future and workshop event type](http://localhost:3002/events?timespan=future&format=WcKmiysAACx_A8NR&aggregations=format%2Caudience%2Cinterpretation%2Clocation%2CisAvailableOnline%2Ctimespan)
You could also treat yourself and run `timespan-filter` on the wc.org repo at the same time to see it work live on the FE.

## How can we measure success?

We're ready to add the filter to the frontend!

## Have we considered potential risks?
As long as it doesn't break existing querying capacities, this is a new feature so is low risk.