### PR TITLE
Add validation on Prismic filter values as well as dates

### DIFF
--- a/api/src/controllers/events.ts
+++ b/api/src/controllers/events.ts
@@ -19,7 +19,7 @@ import { ResultList } from '@weco/content-api/src/types/responses';
 import { HttpError } from './error';
 import { paginationElasticBody, PaginationQueryParameters } from './pagination';
 import { timespans } from './utils';
-import { queryValidator } from './validation';
+import { prismicIdValidator, queryValidator } from './validation';
 
 type QueryParams = {
   query?: string;
@@ -92,6 +92,11 @@ const paramsValidator = (params: QueryParams): QueryParams => {
       timespan: params.timespan,
     });
   }
+
+  if (params.audience) prismicIdValidator(params.audience, 'audiences');
+  if (params.interpretation)
+    prismicIdValidator(params.interpretation, 'interpretations');
+  if (params.format) prismicIdValidator(params.format, 'formats');
 
   const hasIsAvailableOnline =
     isAvailableOnline &&
@@ -182,6 +187,7 @@ const eventsController = (clients: Clients, config: Config): EventsHandler => {
             'Your query contained too many terms, please try again with a simpler query',
         });
       }
+
       throw error;
     }
   });

--- a/api/src/controllers/validation.ts
+++ b/api/src/controllers/validation.ts
@@ -120,14 +120,14 @@ export const prismicIdValidator = (
     });
 };
 
-// Checks if the date is a valid year of 3 or 4 digits
+// Checks if the date is of the format YYYY-MM-DD
 export const dateValidator = (date: string) => {
-  const dateRegex = /^\d{3,4}$/;
+  const dateRegex = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
   if (!dateRegex.test(date))
     throw new HttpError({
       status: 400,
       label: 'Bad Request',
-      description: `${date} is not a valid year.`,
+      description: `${date} is not a valid YYYY-MM-DD format.`,
     });
 };

--- a/api/src/controllers/validation.ts
+++ b/api/src/controllers/validation.ts
@@ -92,3 +92,42 @@ export const validateDate = (input: string): Date => {
   }
   return date;
 };
+
+// From looksLikePrismicId in .org repo:
+// \w: Matches any word character (alphanumeric & underscore).
+//     Only matches low-ascii characters (no accented or non-roman characters).
+//     Equivalent to [A-Za-z0-9_].
+// Added "-" to be matched as well.
+// + means empty strings will return false.
+export const prismicIdValidator = (
+  filterValues: string,
+  filterName: string
+) => {
+  const filterValuesArray = filterValues.split(',');
+  const invalidValues: string[] = [];
+
+  filterValuesArray.forEach(filterValue => {
+    if (!/^[\w-]+$/.test(filterValue)) {
+      invalidValues.push(filterValue);
+    }
+  });
+
+  if (invalidValues.length > 0)
+    throw new HttpError({
+      status: 400,
+      label: 'Bad Request',
+      description: `At least one invalid value has been passed in the ${filterName} filter: ${invalidValues.length > 1 ? invalidValues.join(', ') : invalidValues}`,
+    });
+};
+
+// Checks if the date is a valid year of 3 or 4 digits
+export const dateValidator = (date: string) => {
+  const dateRegex = /^\d{3,4}$/;
+
+  if (!dateRegex.test(date))
+    throw new HttpError({
+      status: 400,
+      label: 'Bad Request',
+      description: `${date} is not a valid year.`,
+    });
+};


### PR DESCRIPTION
## What does this change?

We were getting [a lot of errors in the alerts channel](https://wellcome.slack.com/archives/CQ720BG02/p1744963470565019) because bad values were passed in the Content API's filters (e.g. `1'"` as an audience...), which returns a 500 and logs in the channel.

I added a validator for Prismic Ids (which also account for the few uuids we pass in the Content API), which will at least check that only alphanumerical values are passed in and return a more useful error message as "Bad Request". 

I also added a paramsValidator to `articles`, including a date checker (for `YYYY-MM-DD`, which according to tests (query.test.ts) is what we want from a date). We don't currently use Dates as a filter in articles, but we'll be covered when we do.

Results in;
<img width="746" alt="Screenshot 2025-04-22 at 16 29 55" src="https://github.com/user-attachments/assets/3b415668-c876-4932-930f-84bbaacf0062" />

The FE still returns it as a "Content API Error", which we could address should we want to - do we? (I feel like; not necessarily, why would normal users come across these?)
<img width="500" alt="Screenshot 2025-04-22 at 16 47 43" src="https://github.com/user-attachments/assets/c968516b-1c83-4edb-8139-539609006368" />


## How to test

Run locally bad requests (take inspo from the alerts channel link above!)
Run good requests, they should be unaffected.

## How can we measure success?

Less "expected fails" in the alerts channel, making it more useful.

## Have we considered potential risks?
N/A?