### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -1,4 +1,6 @@
 name: 'Typescript'
+permissions:
+  contents: read
 on:
   push:
 


### PR DESCRIPTION
My first Copilot PR ✨ 🙃 

Potential fix for [https://github.com/wellcomecollection/content-api/security/code-scanning/1](https://github.com/wellcomecollection/content-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (applies to all jobs) to explicitly set the permissions to `contents: read`. This is sufficient for the current workflow, as it only checks out the repository and installs dependencies without requiring any write access.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
