### PR TITLE
Remove labels for workType

### DIFF
--- a/pipeline/src/transformers/addressables/helpers/catalogue-api.ts
+++ b/pipeline/src/transformers/addressables/helpers/catalogue-api.ts
@@ -1,5 +1,4 @@
 // Helper functions for working with the Wellcome Collection Catalogue API
-import { isNotUndefined } from '@weco/content-pipeline/src/helpers/type-guards';
 
 const getWorkUrl = (workId: string): string => {
   return `https://api.wellcomecollection.org/catalogue/v2/works/${workId}?include=contributors%2Cproduction`;
@@ -17,10 +16,10 @@ export type TransformedWork = {
   id: string;
   title: string;
   type: string;
+  workType?: string;
   thumbnailUrl?: string;
   date?: string;
   mainContributor?: string;
-  labels: string[];
 };
 
 // Types for the Catalogue API response (partial, based on what we need)
@@ -45,9 +44,6 @@ type CatalogueWork = {
   workType?: {
     label: string;
   };
-  availabilities?: {
-    id: string;
-  }[];
 };
 
 export const transformWork = (work: CatalogueWork): TransformedWork => {
@@ -59,22 +55,14 @@ export const transformWork = (work: CatalogueWork): TransformedWork => {
     contributor => contributor.primary
   )?.agent.label;
 
-  const isOnline = (work.availabilities ?? []).some(
-    ({ id }) => id === 'online'
-  );
-
-  const labels = (
-    isOnline ? [work.workType?.label, 'Online'] : [work.workType?.label]
-  ).filter(isNotUndefined);
-
   return {
     id: work.id,
     title: work.title,
-    type: work.type,
+    type: work.type, // TODO is this useful? It's always "Work"
+    workType: work.workType?.label,
     thumbnailUrl: work.thumbnail?.url,
     date,
     mainContributor,
-    labels,
   };
 };
 export const fetchAllWorks = async (

--- a/pipeline/test/prismic-snapshots/WXInvioAABlsbLHu.articles.json
+++ b/pipeline/test/prismic-snapshots/WXInvioAABlsbLHu.articles.json
@@ -3,7 +3,7 @@
   "uid": "ken-s-ten--looking-back-at-ten-years-of-wellcome-collection",
   "url": null,
   "type": "articles",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WXInvioAABlsbLHu%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WXInvioAABlsbLHu%22%29+%5D%5D",
   "tags": ["delist"],
   "first_publication_date": "2024-05-07T15:46:28+0000",
   "last_publication_date": "2024-10-23T14:49:47+0000",
@@ -528,7 +528,7 @@
             "name": "Ken Arnold"
           },
           "link_type": "Document",
-          "key": "f168d632-0767-40ab-8234-2ac4d21a62a2",
+          "key": "9a655d58-6ace-4c9b-a452-457f915ae33b",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/WcvPmSsAAG5B5-ox.articles.json
+++ b/pipeline/test/prismic-snapshots/WcvPmSsAAG5B5-ox.articles.json
@@ -3,7 +3,7 @@
   "uid": "the-key-to-memory--follow-your-nose",
   "url": null,
   "type": "articles",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WcvPmSsAAG5B5-ox%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WcvPmSsAAG5B5-ox%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2017-10-11T08:30:00+0000",
   "last_publication_date": "2024-10-23T14:36:08+0000",
@@ -605,7 +605,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "a9f3bdca-51c9-411e-8d89-f9f9b879b2c7",
+          "key": "90578b5e-ea32-46c1-9207-33d3ef52057f",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/Wn3Q3SoAACsAIeFI.event-formats.json
+++ b/pipeline/test/prismic-snapshots/Wn3Q3SoAACsAIeFI.event-formats.json
@@ -3,7 +3,7 @@
   "uid": null,
   "url": null,
   "type": "event-formats",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Wn3Q3SoAACsAIeFI%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Wn3Q3SoAACsAIeFI%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2018-02-09T16:48:32+0000",
   "last_publication_date": "2019-10-22T09:37:37+0000",

--- a/pipeline/test/prismic-snapshots/WsuS_R8AACS1Nwlx.collection-venue.json
+++ b/pipeline/test/prismic-snapshots/WsuS_R8AACS1Nwlx.collection-venue.json
@@ -3,7 +3,7 @@
   "uid": null,
   "url": null,
   "type": "collection-venue",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WsuS_R8AACS1Nwlx%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WsuS_R8AACS1Nwlx%22%29+%5D%5D",
   "tags": ["ShortNoticeClosure"],
   "first_publication_date": "2018-04-09T16:21:23+0000",
   "last_publication_date": "2025-08-11T09:07:17+0000",

--- a/pipeline/test/prismic-snapshots/XK9p2RIAAO1vQn__.webcomics.json
+++ b/pipeline/test/prismic-snapshots/XK9p2RIAAO1vQn__.webcomics.json
@@ -3,7 +3,7 @@
   "uid": "groan",
   "url": null,
   "type": "webcomics",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22XK9p2RIAAO1vQn__%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22XK9p2RIAAO1vQn__%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2019-04-12T09:00:00+0000",
   "last_publication_date": "2024-10-23T10:21:31+0000",
@@ -37,7 +37,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "c86db5f0-8a83-475d-bfba-e2bfd3a07109",
+      "key": "ea3cd7c8-f5da-4a47-a6d6-634d1bdd4291",
       "isBroken": false
     },
     "contributors": [
@@ -60,7 +60,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "7682ced3-6968-4ac9-b4e6-97cae31f8481",
+          "key": "1c4d5418-f2fd-46df-ae2d-e39e1709ba20",
           "isBroken": false
         },
         "contributor": {
@@ -75,7 +75,7 @@
             "name": "Rob Bidder"
           },
           "link_type": "Document",
-          "key": "ad2dd7a8-2375-4986-943e-2f8e5b811cef",
+          "key": "514f3b5a-3b14-43a3-9331-e9fd1aae0d63",
           "isBroken": false
         }
       }
@@ -190,7 +190,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "5097a2ae-b529-49b3-8ae8-2da5d3a7a010",
+          "key": "87dcc591-3a8b-43c9-a13d-db8aa0c616f6",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/XUGruhEAACYASyJh.webcomics.json
+++ b/pipeline/test/prismic-snapshots/XUGruhEAACYASyJh.webcomics.json
@@ -3,7 +3,7 @@
   "uid": "footpath",
   "url": null,
   "type": "webcomics",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22XUGruhEAACYASyJh%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22XUGruhEAACYASyJh%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2019-08-02T09:00:00+0000",
   "last_publication_date": "2024-10-23T10:21:33+0000",
@@ -37,7 +37,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "d924bb41-83cf-4f62-9709-0592d7b64d3d",
+      "key": "14a7e39e-6504-41c1-bdcd-3f920eebb6ad",
       "isBroken": false
     },
     "contributors": [
@@ -60,7 +60,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "3e081feb-582b-4db5-bff7-30ecded8d919",
+          "key": "987e118d-0f90-4cc1-8dd6-7cb2c0948b96",
           "isBroken": false
         },
         "contributor": {
@@ -75,7 +75,7 @@
             "name": "Rob Bidder"
           },
           "link_type": "Document",
-          "key": "ab862c62-762e-47ba-a361-3204134f134a",
+          "key": "43239837-60aa-445f-a1c2-c4a6287e1343",
           "isBroken": false
         }
       }
@@ -190,7 +190,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "e1481fe1-5d90-418e-9171-3645742f01e1",
+          "key": "54de7a98-a7f7-4cf3-b65f-0f1c7f0c71e7",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/Y0U4GBEAAA__16h6.articles.json
+++ b/pipeline/test/prismic-snapshots/Y0U4GBEAAA__16h6.articles.json
@@ -3,7 +3,7 @@
   "uid": "tracing-the-roots-of-our-fears-and-fixations",
   "url": null,
   "type": "articles",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Y0U4GBEAAA__16h6%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Y0U4GBEAAA__16h6%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-10-18T09:00:00+0000",
   "last_publication_date": "2024-10-23T14:38:42+0000",
@@ -37,7 +37,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "e40b7b9b-a459-4f24-b93f-c95aea36fd1d",
+      "key": "4d64581c-99d9-45ed-a9ba-b4780b3f5534",
       "isBroken": false
     },
     "body": [
@@ -624,7 +624,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "1b93e597-f70d-4194-9f16-aaa228ecf4c3",
+          "key": "e56bb8fc-38a0-4ba8-aec2-04c2ef72524e",
           "isBroken": false
         },
         "contributor": {
@@ -639,7 +639,7 @@
             "name": "Kate Summerscale"
           },
           "link_type": "Document",
-          "key": "65a075aa-1cec-440e-86d5-07327fdbd563",
+          "key": "f802c779-21ed-408f-944f-1ffcc028c00a",
           "isBroken": false
         }
       },
@@ -662,7 +662,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "94d9f29f-ee35-4538-a20e-3e99d8f5e662",
+          "key": "ede179b1-fe61-447c-8929-cbc23b115462",
           "isBroken": false
         },
         "contributor": {
@@ -677,7 +677,7 @@
             "name": "Tim Robinson"
           },
           "link_type": "Document",
-          "key": "4da4875a-9780-455c-b061-ed99398e9539",
+          "key": "1e8d5657-aff8-4853-9f1d-ab6eb3e13245",
           "isBroken": false
         }
       }
@@ -793,7 +793,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "7e0568cc-1b27-4ebe-9f73-299b9e7a09eb",
+          "key": "b5a87f9c-d7d2-4ebf-85b0-69a7de905e94",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/YbjAThEAACEAcPYF.articles.json
+++ b/pipeline/test/prismic-snapshots/YbjAThEAACEAcPYF.articles.json
@@ -3,7 +3,7 @@
   "uid": "the-enigma-of-the-medieval-folding-almanac",
   "url": null,
   "type": "articles",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YbjAThEAACEAcPYF%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YbjAThEAACEAcPYF%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-01-10T10:59:43+0000",
   "last_publication_date": "2025-01-08T16:22:07+0000",
@@ -454,7 +454,7 @@
                     "name": "Lalita Kaplish"
                   },
                   "link_type": "Document",
-                  "key": "4f5d7b5c-1c8e-4e58-b9e8-4083ee13838e",
+                  "key": "8610cb20-08d1-4f8f-b2ba-2801b17c79ef",
                   "isBroken": false
                 }
               }

--- a/pipeline/test/prismic-snapshots/YvtXgxAAACMA9j5d.people.json
+++ b/pipeline/test/prismic-snapshots/YvtXgxAAACMA9j5d.people.json
@@ -3,7 +3,7 @@
   "uid": null,
   "url": null,
   "type": "people",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YvtXgxAAACMA9j5d%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YvtXgxAAACMA9j5d%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-08-16T08:39:34+0000",
   "last_publication_date": "2022-10-04T10:37:30+0000",

--- a/pipeline/test/prismic-snapshots/Yzv9ChEAABfUrkVp.events.json
+++ b/pipeline/test/prismic-snapshots/Yzv9ChEAABfUrkVp.events.json
@@ -3,7 +3,7 @@
   "uid": "the-healing-pavilion",
   "url": null,
   "type": "exhibitions",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Yzv9ChEAABfUrkVp%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Yzv9ChEAABfUrkVp%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-10-12T11:11:45+0000",
   "last_publication_date": "2024-10-31T15:26:35+0000",
@@ -45,7 +45,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "297a0fa7-2778-413e-b9a9-3ee675afa4f6",
+          "key": "b6e8bfda-bce5-4d3b-a67d-d392bdc6a209",
           "isBroken": false
         },
         "contributor": {
@@ -60,7 +60,7 @@
             "name": "Grace Ndiritu"
           },
           "link_type": "Document",
-          "key": "4e1b9303-e7ea-47e6-86f4-df57cebda964",
+          "key": "35e02964-e5f9-40bc-8beb-fd4c58767b6d",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/Z1hLIxAAAB4AVAWG.events.json
+++ b/pipeline/test/prismic-snapshots/Z1hLIxAAAB4AVAWG.events.json
@@ -3,7 +3,7 @@
   "uid": "zines-forever-diy-publishing-and-disability-justice",
   "url": null,
   "type": "exhibitions",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z1hLIxAAAB4AVAWG%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z1hLIxAAAB4AVAWG%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2024-12-16T16:18:35+0000",
   "last_publication_date": "2025-04-29T16:52:41+0000",

--- a/pipeline/test/prismic-snapshots/ZFt0WhQAAHnPEH7P.events.json
+++ b/pipeline/test/prismic-snapshots/ZFt0WhQAAHnPEH7P.events.json
@@ -3,7 +3,7 @@
   "uid": "land-body-ecologies-festival-day-two",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZFt0WhQAAHnPEH7P%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZFt0WhQAAHnPEH7P%22%29+%5D%5D",
   "tags": ["LBEF"],
   "first_publication_date": "2023-05-25T15:00:01+0000",
   "last_publication_date": "2025-04-23T16:16:53+0000",
@@ -188,7 +188,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "2c13f3d2-1ef5-4304-b711-54c08c22bacf",
+                  "key": "22831fc4-59e8-4ca3-9728-951128eb0d2a",
                   "isBroken": false
                 }
               }
@@ -218,7 +218,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "f2f3992e-fe92-4609-bc2e-f81dfc9e72e8",
+              "key": "f782e47d-5f43-4aae-b0bd-144b3d2023d0",
               "isBroken": false
             }
           },
@@ -280,7 +280,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "2920ac70-9e0d-4e8e-a30b-0d443f737bd1",
+                  "key": "47faeb42-a3e4-4813-bb56-a38a91e01cad",
                   "isBroken": false
                 }
               }
@@ -310,7 +310,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "d26aab41-e47e-4861-97f1-e49814e91e7d",
+              "key": "0b48b6f8-aced-4aeb-a8ce-b2c1e8cbc946",
               "isBroken": false
             }
           },
@@ -372,7 +372,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "42e0c146-7ddc-4a8e-9831-f766ba6b762f",
+                  "key": "0ff97460-da69-4a8b-8d45-4de3a76c30a8",
                   "isBroken": false
                 }
               }
@@ -398,7 +398,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "91dfad8e-875e-49c8-b194-ab18937e39e0",
+                  "key": "94e07f81-9859-4f3b-a139-c45b0dc4b930",
                   "isBroken": false
                 }
               },
@@ -421,7 +421,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "a5401819-04a7-4bf7-b423-ba7fc4b8ced6",
+                  "key": "e7c3bacb-91d0-4b8b-b9f6-1152736f5819",
                   "isBroken": false
                 }
               }
@@ -444,7 +444,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "5fa6a2fd-f5c2-4726-a1fd-db6206ce3d3c",
+              "key": "33f1d748-4ac0-4ab2-b963-184871a0f27f",
               "isBroken": false
             }
           },
@@ -506,7 +506,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "d215fb90-5795-42b9-bd73-2c01e4fc7d90",
+                  "key": "42c7123a-16ba-408b-8a88-f6b60f16ace0",
                   "isBroken": false
                 }
               }
@@ -536,7 +536,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "bca34d03-81ad-48bb-a701-b3b6f9433839",
+              "key": "a7bf7d2c-c97d-4f8c-93eb-4e87b4812011",
               "isBroken": false
             }
           },
@@ -598,7 +598,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "9be3cbf8-6238-43d6-9390-fd7abfa27e4d",
+                  "key": "552b6634-c4a0-4c88-810c-c99bce916707",
                   "isBroken": false
                 }
               }
@@ -628,7 +628,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "b13ca4f3-040e-432d-a3ff-49b01257db65",
+              "key": "10c9cb40-a175-40d4-90c6-663ce7805ef9",
               "isBroken": false
             }
           },
@@ -690,7 +690,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "b025632c-3806-4480-b017-2b6a21f640d3",
+                  "key": "3383a858-4f40-4d32-8c8e-6c7f7770920a",
                   "isBroken": false
                 }
               }
@@ -720,7 +720,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "9cc090f2-300c-4fd0-b966-8e9674aae764",
+              "key": "32e43b74-15a3-4841-9817-2c7aabc23da0",
               "isBroken": false
             }
           },
@@ -782,7 +782,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "0145d9e4-3a76-451a-b9b2-fd36e1ad250f",
+                  "key": "c06f20f8-07bc-42ce-b010-f02a9f074a92",
                   "isBroken": false
                 }
               }
@@ -812,7 +812,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "fce43782-cfaf-4346-989c-88096d279ebd",
+              "key": "7457bb67-b7bf-4b8a-9a25-8dfda332550c",
               "isBroken": false
             }
           },
@@ -874,7 +874,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "07209b49-a857-44ef-8f05-9e5b9a349ccb",
+                  "key": "e1f3a36b-8dce-4da0-9ce0-ba9d20e10d56",
                   "isBroken": false
                 }
               }
@@ -904,7 +904,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "84cec815-9f28-4e9d-ae8e-33a227f753ec",
+              "key": "0aacab92-8985-46ae-9c0e-7bd3b6f13ea3",
               "isBroken": false
             }
           },
@@ -966,7 +966,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "7a0a55a2-db0d-4d62-b32e-bdee6c3f8f4b",
+                  "key": "a43e5940-da45-4a81-9530-3ccdfc29eeae",
                   "isBroken": false
                 }
               }
@@ -996,7 +996,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "c818144f-4206-48db-8966-4c424796dc4b",
+              "key": "3082661c-1951-4587-995f-7ebfaaa4b6c9",
               "isBroken": false
             }
           },
@@ -1058,7 +1058,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "91802499-4104-4ccb-9446-61ec711731dc",
+                  "key": "eff032df-a4bb-4d86-bfd5-8c775c411b1d",
                   "isBroken": false
                 }
               }
@@ -1088,7 +1088,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "5aab79ea-3551-465c-890e-8222a3e13657",
+              "key": "d28ed7fa-2a5f-4237-9092-3e04d927c2ee",
               "isBroken": false
             }
           },
@@ -1150,7 +1150,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "e6055c31-ac21-4f94-bc63-fa3982b534db",
+                  "key": "3c33fcb8-edc6-4748-9cfc-37061fa5b010",
                   "isBroken": false
                 }
               }
@@ -1180,7 +1180,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "5b4f546a-50d7-4fad-bf8a-c7436d6fe5ef",
+              "key": "071ded9d-bf31-4a64-8435-8347d44ad2b0",
               "isBroken": false
             }
           },
@@ -1242,7 +1242,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "1cbc3435-f723-4f45-85eb-ae0cc18391f1",
+                  "key": "28c3864b-e6ea-44d1-866b-04d7dc570867",
                   "isBroken": false
                 }
               }
@@ -1272,7 +1272,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "a2626da8-b155-4a09-8117-a446068b490e",
+              "key": "be76544b-99de-4e76-bf6c-731a1e196c8b",
               "isBroken": false
             }
           },
@@ -1334,7 +1334,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "2915e87b-3b39-461c-8fed-4fa67ea2f7eb",
+                  "key": "f99da75a-29bc-4656-8679-4e6de020ba69",
                   "isBroken": false
                 }
               },
@@ -1357,7 +1357,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "a54cfb2b-e5be-4924-8c00-019dab10f70c",
+                  "key": "56268dd7-e28f-4a06-b6f7-2aea431ed896",
                   "isBroken": false
                 }
               }
@@ -1387,7 +1387,7 @@
                 ]
               },
               "link_type": "Document",
-              "key": "b04c448d-2bcc-4e99-84f4-40ae965e35a0",
+              "key": "37dedf0e-047c-4d51-b06e-5ffe9a9a77d9",
               "isBroken": false
             }
           },
@@ -1609,7 +1609,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "5b5ef5a1-955a-4e87-884d-8a33e5d8348c",
+                  "key": "77fe63b4-fb59-4b78-8672-76d734aa205e",
                   "isBroken": false
                 }
               },
@@ -1632,7 +1632,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "3b90cae7-c322-4b2b-b745-82bbf141c7f0",
+                  "key": "5b030940-55cd-41dc-8e1d-60b4973b5aa4",
                   "isBroken": false
                 }
               }

--- a/pipeline/test/prismic-snapshots/ZJLZoRAAACIARz42.events.json
+++ b/pipeline/test/prismic-snapshots/ZJLZoRAAACIARz42.events.json
@@ -3,7 +3,7 @@
   "uid": "perspective-tour-with-jess-dobkin",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZJLZoRAAACIARz42%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZJLZoRAAACIARz42%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2023-07-27T15:00:00+0000",
   "last_publication_date": "2025-04-23T16:15:40+0000",

--- a/pipeline/test/prismic-snapshots/ZQgdkREAAAbr6cRR.events.json
+++ b/pipeline/test/prismic-snapshots/ZQgdkREAAAbr6cRR.events.json
@@ -3,7 +3,7 @@
   "uid": "lights-up-on-the-cult-of-beauty-11",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZQgdkREAAAbr6cRR%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZQgdkREAAAbr6cRR%22%29+%5D%5D",
   "tags": ["LightsUpBeauty"],
   "first_publication_date": "2023-10-26T15:00:00+0000",
   "last_publication_date": "2024-10-23T12:53:39+0000",
@@ -42,7 +42,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "fee6a4f7-85c7-4be2-8952-2c3e8b05c3cb",
+          "key": "00453aa4-190a-4c77-8726-12fc057f7c93",
           "isBroken": false
         }
       }
@@ -124,7 +124,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "a4d9fea5-5101-432d-a077-feec92712e90",
+                  "key": "ea0d20d2-3b0a-4d9b-abe6-70e28eda48d2",
                   "isBroken": false
                 }
               }
@@ -138,7 +138,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "00331b1c-526c-428b-9b19-d73a95642703",
+          "key": "4213196e-1d51-4187-9c84-4cc1ff575926",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -196,7 +196,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "83cdc2ca-9c81-4bf0-912c-1c11f2827876",
+                  "key": "36c4b4ac-35c0-4cc5-8559-e090b1ef5d9d",
                   "isBroken": false
                 }
               }
@@ -221,7 +221,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "872f2db3-05ae-419f-8ed0-93ca8e873d9c",
+                  "key": "23ca9b30-87da-483b-ba69-05ea968b07b3",
                   "isBroken": false
                 }
               }
@@ -244,12 +244,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "1c7d3f63-4e95-4526-acdb-c16bcb8a0eee",
+              "key": "dd7bc0df-eab5-4a34-9175-a1c5c098e50a",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "408b8454-2cc5-4e10-b00b-6f9fc1076bcb",
+          "key": "af45efca-f775-48ca-a047-d256d226cb9e",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -306,7 +306,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "dc8d3faf-fe77-41c5-96e2-868878045651",
+                  "key": "a424818c-8cea-4758-82ec-1f1986196913",
                   "isBroken": false
                 }
               }
@@ -320,7 +320,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "56275918-7c1f-4d9c-a043-e32c6a4aab68",
+          "key": "e5378c4f-5298-4ebb-91b3-b6b428ea1cc8",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -378,7 +378,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "1bdc7e28-830a-433a-896a-f0aaa7ab1138",
+                  "key": "02d55a35-6562-4f50-8f62-73d03680705c",
                   "isBroken": false
                 }
               }
@@ -403,7 +403,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "9673e9b4-fc90-494d-96c4-aaf7b6888166",
+                  "key": "e92c258d-cedf-4348-a90a-5216dbc91018",
                   "isBroken": false
                 }
               }
@@ -426,12 +426,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "e506b8e2-2d54-4fbe-b594-336794433d62",
+              "key": "0a82bf61-e905-4452-9bff-a7d686245ac1",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "ded9322e-1f31-4286-8da5-011d61e5f6bd",
+          "key": "c82f28ad-77dd-4cac-9a78-d3b789f9a6a6",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -488,7 +488,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "43c37baa-9ea2-4ee4-b07d-cae3fd26f3f4",
+                  "key": "dda71506-dfda-44a5-b93b-9f97d6d652c1",
                   "isBroken": false
                 }
               }
@@ -502,7 +502,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "732b15bc-c0b8-454e-9767-4365351a45f4",
+          "key": "d2892b76-add2-46e1-8781-9049f0dbb87f",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -560,7 +560,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "9d184ff1-cd0c-4680-9497-16e626d9e557",
+                  "key": "339b6794-2ed4-4104-bf22-6d90835c3526",
                   "isBroken": false
                 }
               }
@@ -585,7 +585,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "d6cb36de-c169-4fcf-be5f-c30a16d52c04",
+                  "key": "58bf4cb6-08ac-4ca2-9ec6-488046ada009",
                   "isBroken": false
                 }
               }
@@ -608,12 +608,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "6e9142b1-0abd-4275-b2cc-609abda800f8",
+              "key": "3c5613a0-3ed1-45f2-b14c-7607584a3ea6",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "0fe19058-4e05-4c1d-a9d1-46927bd3a4dc",
+          "key": "ca493f04-a05d-4530-b820-c44815a60ba4",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -670,7 +670,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "ec177b09-2409-41fd-a220-d033cc13a8ea",
+                  "key": "fbf25887-2b18-47ca-ac17-d7ae81ac406b",
                   "isBroken": false
                 }
               }
@@ -684,7 +684,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "84d4cf35-3a83-4a29-bd56-a7e9ca040172",
+          "key": "21d02390-9f7f-4bb0-97b6-432849fab9a8",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -742,7 +742,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "c0767735-36c6-4ed2-8cf1-317ffd7fc16c",
+                  "key": "2fb53ee8-5d7a-4e4a-8dd4-6f39b9694339",
                   "isBroken": false
                 }
               }
@@ -767,7 +767,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "9da3f01d-189c-4318-bdc5-e00bdf63d32b",
+                  "key": "d541a4b7-c392-4042-b031-8c8c6504b3b6",
                   "isBroken": false
                 }
               }
@@ -790,12 +790,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "d1b5712e-4a64-44fe-8bc3-e1c2ad7fa205",
+              "key": "d4407acc-2dc1-4ba9-8e19-d03ec2cc77cb",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "13c0ae2d-7879-4d55-ae8d-4c9bdd44eb56",
+          "key": "4045bdee-0aba-4aec-9916-47194544e6b2",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -852,7 +852,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "b728f7dc-4b9f-489a-a8d0-98a2e1b3dbd0",
+                  "key": "5d632a29-9175-458e-99c8-86bf61dd3ee6",
                   "isBroken": false
                 }
               }
@@ -866,7 +866,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "469198e2-cf72-4fb3-acc0-b7844dda420c",
+          "key": "57540d53-f662-45ee-9e9a-a19d586cf554",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -924,7 +924,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "d49d3a4d-d553-4bfa-ab98-856bb0c324a9",
+                  "key": "9b5631d4-16c9-447f-a5de-44a107ce311e",
                   "isBroken": false
                 }
               }
@@ -949,7 +949,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "e34e9c3a-85e5-428b-9a7e-0c320f0dfca7",
+                  "key": "85ed2de0-0b53-46fc-b385-caa5f909d87d",
                   "isBroken": false
                 }
               }
@@ -972,12 +972,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "760b52c4-4a00-49cb-bfbd-fc607ab9d6b2",
+              "key": "f6abc00e-f173-445d-944a-b044fce6291c",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "5c311a6f-9086-4010-bc6c-25fb473ccde5",
+          "key": "067f51b3-0d00-4ad3-be4f-478726366caf",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -1034,7 +1034,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "19c36372-007e-4f79-97c3-f010507cbe61",
+                  "key": "321eec31-b8ec-42b3-acd4-454438bf9187",
                   "isBroken": false
                 }
               }
@@ -1048,7 +1048,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "fd25ec72-6406-43e4-bb7c-69df6733541f",
+          "key": "b6da1ddb-9dff-4eb4-a1fb-82f138a81daa",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -1106,7 +1106,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "176e8057-48f0-4960-9125-c55aeca4f204",
+                  "key": "7f18fa68-6bab-4a22-979f-e924924cb38d",
                   "isBroken": false
                 }
               }
@@ -1131,7 +1131,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "1b9a3f8d-28e1-4af3-8d10-d448ccc16949",
+                  "key": "e306667c-b482-474c-bec5-ffebddd28a97",
                   "isBroken": false
                 }
               }
@@ -1154,12 +1154,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "a06daf23-54b8-452c-ae24-d43108c9603b",
+              "key": "4dcae609-8454-4e67-b5ad-1f86eecb53c2",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "1eeb57f7-1d57-472c-aba4-6a9be65d4c81",
+          "key": "260e9347-9cbd-401f-9b2c-027040204851",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -1216,7 +1216,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "ae45d244-6f12-448f-9403-c217a34232b4",
+                  "key": "c9340044-0d07-4c96-a5b7-81a226c8b0b2",
                   "isBroken": false
                 }
               }
@@ -1230,7 +1230,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "15527b8a-1663-40a8-af09-1823082720ae",
+          "key": "1db643c9-e9ac-421d-a67a-cb78a47491cc",
           "isBroken": false
         },
         "isNotLinked": "yes"
@@ -1288,7 +1288,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "1e964b1d-3439-4a88-896b-90f11a393a2f",
+                  "key": "45bd960e-b7d0-4ff0-b68b-793941da8c6c",
                   "isBroken": false
                 }
               }
@@ -1313,7 +1313,7 @@
                     ]
                   },
                   "link_type": "Document",
-                  "key": "350927d1-ba6f-4863-8c0c-4db13d6d1d16",
+                  "key": "13730db4-b57d-4ca8-8feb-3b9fe6da0193",
                   "isBroken": false
                 }
               }
@@ -1336,12 +1336,12 @@
                 ]
               },
               "link_type": "Document",
-              "key": "e3b4693a-7c43-41fa-baff-e8853b865377",
+              "key": "f64a7552-3b73-4e60-a816-2b6c0883b6f2",
               "isBroken": false
             }
           },
           "link_type": "Document",
-          "key": "e1b2f28a-b70f-4ab6-8d2f-b1d9b993993f",
+          "key": "dcc76747-74bc-4c74-9580-93fc88888cdd",
           "isBroken": false
         },
         "isNotLinked": "yes"

--- a/pipeline/test/prismic-snapshots/ZRrijRIAAJNSARgG.events.json
+++ b/pipeline/test/prismic-snapshots/ZRrijRIAAJNSARgG.events.json
@@ -3,7 +3,7 @@
   "uid": "standards--my-right-to-beauty",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZRrijRIAAJNSARgG%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZRrijRIAAJNSARgG%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2023-10-19T15:00:00+0000",
   "last_publication_date": "2025-04-23T16:23:41+0000",

--- a/pipeline/test/prismic-snapshots/ZSPXJBAAACIAiERm.events.json
+++ b/pipeline/test/prismic-snapshots/ZSPXJBAAACIAiERm.events.json
@@ -3,7 +3,7 @@
   "uid": "recipes-for-early-modern-beauty",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZSPXJBAAACIAiERm%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZSPXJBAAACIAiERm%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2023-10-12T15:00:00+0000",
   "last_publication_date": "2024-10-23T12:53:49+0000",
@@ -38,7 +38,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "4ab4f04c-cfee-4f39-9dcb-7e4562b79161",
+      "key": "cae09c1d-9a80-4ae4-9939-d90e8f1c2930",
       "isBroken": false
     },
     "locations": [
@@ -78,7 +78,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "0da34ebf-a3e0-4975-9418-2d4e7adc0e68",
+          "key": "87c03370-82a2-4707-959f-7f9b904e93a6",
           "isBroken": false
         }
       }
@@ -118,7 +118,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "90c8a88b-a3a0-4d8e-be95-9395650e9f25",
+          "key": "61f0b99e-c853-4776-a1db-1bb8f7dbad2e",
           "isBroken": false
         },
         "contributor": {
@@ -133,7 +133,7 @@
             "name": "Jill Burke"
           },
           "link_type": "Document",
-          "key": "a9bb96bc-3bd5-435e-a9d3-ff7912dd7f16",
+          "key": "dc99edfd-711b-4f91-bfe5-dc016e23f6a8",
           "isBroken": false
         }
       },
@@ -156,7 +156,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "2faafc8d-7f86-4b38-9bdf-6faf63f2788d",
+          "key": "c9613d9f-ca5f-47a4-aa01-904098079b24",
           "isBroken": false
         },
         "contributor": {
@@ -171,7 +171,7 @@
             "name": "Hayley O’Kell"
           },
           "link_type": "Document",
-          "key": "6d6bd304-3bb5-4c9a-92d9-f93a547c2606",
+          "key": "281da38c-7436-4d70-a196-e0a5242aafa1",
           "isBroken": false
         }
       },
@@ -194,7 +194,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "9c09432b-cc52-41ad-87c8-611d080ff220",
+          "key": "65a04c33-8b8a-4fcc-a5db-797946bd30ce",
           "isBroken": false
         },
         "contributor": {
@@ -209,7 +209,7 @@
             "name": "Romana Sammern"
           },
           "link_type": "Document",
-          "key": "58eefc17-3075-468e-94aa-abcf303b36e7",
+          "key": "faa119d2-4b2c-4905-b139-dddc274e3427",
           "isBroken": false
         }
       },
@@ -232,7 +232,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "03187161-873a-4c85-bc4b-f5e3151c1375",
+          "key": "2ed13098-2cbc-4182-96e6-5d8785717bad",
           "isBroken": false
         },
         "contributor": {
@@ -247,7 +247,7 @@
             "name": "Patricia Akhimie"
           },
           "link_type": "Document",
-          "key": "cd178662-1204-49da-9d77-44b7b100e327",
+          "key": "129a2934-89dd-477a-9aac-1181aca045ae",
           "isBroken": false
         }
       }
@@ -363,7 +363,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "b3633c2e-4684-4ca6-8d2a-717fba96d85a",
+          "key": "0a3adf76-68de-42b5-a8dd-79bd6585363e",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/ZTevFxAAACQAyHEk.events.json
+++ b/pipeline/test/prismic-snapshots/ZTevFxAAACQAyHEk.events.json
@@ -3,7 +3,7 @@
   "uid": "sexing-up-the-internet",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZTevFxAAACQAyHEk%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZTevFxAAACQAyHEk%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2023-10-26T15:04:01+0000",
   "last_publication_date": "2024-10-23T12:51:41+0000",
@@ -37,7 +37,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "fa157ec0-09c0-4b7e-9e83-a9b768b56e38",
+      "key": "4aac46b4-13c6-489a-ac0f-0a3b824634b7",
       "isBroken": false
     },
     "locations": [
@@ -60,7 +60,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "a7986539-db36-4a29-afff-0f4157f433c5",
+          "key": "8419f612-2599-4b80-8c09-d0328aa8aa2c",
           "isBroken": false
         }
       }
@@ -117,7 +117,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "7b6be361-92a3-4efd-a393-b638da9893d0",
+          "key": "5de2c27b-cb56-48bd-973a-1c3b5f853684",
           "isBroken": false
         },
         "contributor": {
@@ -132,7 +132,7 @@
             "name": "Sophia Smith Galer"
           },
           "link_type": "Document",
-          "key": "bb130f56-74cf-4b28-a2a5-22543f3a0d3a",
+          "key": "82ec730e-bb5e-4088-8194-c1b9891b93d0",
           "isBroken": false
         }
       },
@@ -155,7 +155,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "c6c8ad68-8663-4fc6-b60c-5fc705b38191",
+          "key": "a721f52e-e553-45a8-8204-4dd01be86016",
           "isBroken": false
         },
         "contributor": {
@@ -170,7 +170,7 @@
             "name": "Alice White"
           },
           "link_type": "Document",
-          "key": "918253d0-4e30-4bcb-af46-ec8d757a90b1",
+          "key": "5089587b-6f1b-499c-9bb7-97f795c38888",
           "isBroken": false
         }
       },
@@ -193,7 +193,7 @@
             ]
           },
           "link_type": "Document",
-          "key": "38d8ae7c-65c6-4a66-9088-df75e6507e53",
+          "key": "7a40b183-db4d-4221-9706-4e7a60341d56",
           "isBroken": false
         },
         "contributor": {
@@ -208,7 +208,7 @@
             "name": "Anne Philpott"
           },
           "link_type": "Document",
-          "key": "7e9c61f5-89fe-4b2f-87fe-09856ac9b114",
+          "key": "fcc0b14c-728f-47a4-ae36-5ea1cd6fe444",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/addressables/WwVK3CAAAHm5Exxr.books.json
+++ b/pipeline/test/prismic-snapshots/addressables/WwVK3CAAAHm5Exxr.books.json
@@ -3,7 +3,7 @@
   "uid": "brains",
   "url": null,
   "type": "books",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WwVK3CAAAHm5Exxr%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WwVK3CAAAHm5Exxr%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2018-05-24T13:12:21+0000",
   "last_publication_date": "2024-07-22T11:06:39+0000",
@@ -74,7 +74,7 @@
             "name": "Marius Kwint"
           },
           "link_type": "Document",
-          "key": "6dc4de12-1827-4721-8b40-444cb39be89d",
+          "key": "00ea04b8-983d-4bb8-957e-7789f7d638b8",
           "isBroken": false
         }
       },
@@ -91,7 +91,7 @@
             "name": "Richard Wingate"
           },
           "link_type": "Document",
-          "key": "cbc0dc57-1544-4d2c-b928-defb149b8f73",
+          "key": "fc81f40e-5146-4500-b8bd-e22ba5e9734b",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/addressables/X84FvhIAACUAqiqp.seasons.json
+++ b/pipeline/test/prismic-snapshots/addressables/X84FvhIAACUAqiqp.seasons.json
@@ -3,7 +3,7 @@
   "uid": "what-does-it-mean-to-be-human--now-",
   "url": null,
   "type": "seasons",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22X84FvhIAACUAqiqp%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22X84FvhIAACUAqiqp%22%29+%5D%5D",
   "tags": ["delist"],
   "first_publication_date": "2020-12-07T10:37:12+0000",
   "last_publication_date": "2024-10-22T15:27:05+0000",

--- a/pipeline/test/prismic-snapshots/addressables/YLokOhAAACQAf8Hd.projects.json
+++ b/pipeline/test/prismic-snapshots/addressables/YLokOhAAACQAf8Hd.projects.json
@@ -3,7 +3,7 @@
   "uid": "updating-happiness",
   "url": null,
   "type": "projects",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YLokOhAAACQAf8Hd%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YLokOhAAACQAf8Hd%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2021-06-08T09:50:40+0000",
   "last_publication_date": "2024-10-22T15:40:26+0000",
@@ -37,7 +37,7 @@
         ]
       },
       "link_type": "Document",
-      "key": "683a70ea-1deb-4eb8-943d-9b58d27b8d06",
+      "key": "37611b7d-8358-4922-9568-2790c6f90cdf",
       "isBroken": false
     },
     "body": [

--- a/pipeline/test/prismic-snapshots/addressables/YdXSvhAAAIAW7YXQ.pages.json
+++ b/pipeline/test/prismic-snapshots/addressables/YdXSvhAAAIAW7YXQ.pages.json
@@ -3,7 +3,7 @@
   "uid": "venue-hire-terms-and-conditions-of-booking",
   "url": null,
   "type": "pages",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YdXSvhAAAIAW7YXQ%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22YdXSvhAAAIAW7YXQ%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-01-17T13:42:14+0000",
   "last_publication_date": "2025-05-30T19:01:25+0000",

--- a/pipeline/test/prismic-snapshots/addressables/Yzv9ChEAABfUrkVp.exhibitions.json
+++ b/pipeline/test/prismic-snapshots/addressables/Yzv9ChEAABfUrkVp.exhibitions.json
@@ -3,7 +3,7 @@
   "uid": "the-healing-pavilion",
   "url": null,
   "type": "exhibitions",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Yzv9ChEAABfUrkVp%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Yzv9ChEAABfUrkVp%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2022-10-12T11:11:45+0000",
   "last_publication_date": "2024-10-31T15:26:35+0000",
@@ -38,7 +38,7 @@
             "name": "Grace Ndiritu"
           },
           "link_type": "Document",
-          "key": "7260c5b5-dc96-4a43-b781-5101f827d173",
+          "key": "e4209fda-dda0-409e-a409-b56ccc1bf219",
           "isBroken": false
         }
       }

--- a/pipeline/test/prismic-snapshots/addressables/Z9vxBBQAACEAfZwp.events.json
+++ b/pipeline/test/prismic-snapshots/addressables/Z9vxBBQAACEAfZwp.events.json
@@ -3,7 +3,7 @@
   "uid": "a-peoples-history-of-death-with-molly-conisbee",
   "url": null,
   "type": "events",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z9vxBBQAACEAfZwp%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z9vxBBQAACEAfZwp%22%29+%5D%5D",
   "tags": ["PHOD"],
   "first_publication_date": "2025-04-03T14:52:29+0000",
   "last_publication_date": "2025-04-28T09:22:37+0000",

--- a/pipeline/test/prismic-snapshots/addressables/Zs8EuRAAAB4APxrA.visual-stories.json
+++ b/pipeline/test/prismic-snapshots/addressables/Zs8EuRAAAB4APxrA.visual-stories.json
@@ -3,7 +3,7 @@
   "uid": "hard-graft",
   "url": null,
   "type": "visual-stories",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8EuRAAAB4APxrA%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8EuRAAAB4APxrA%22%29+%5D%5D",
   "tags": ["hard-graft"],
   "first_publication_date": "2024-10-23T11:49:18+0000",
   "last_publication_date": "2025-03-19T15:37:45+0000",

--- a/pipeline/test/prismic-snapshots/addressables/Zs8mohAAAB4AP4sc.exhibition-texts.json
+++ b/pipeline/test/prismic-snapshots/addressables/Zs8mohAAAB4AP4sc.exhibition-texts.json
@@ -3,7 +3,7 @@
   "uid": "hard-graft-exhibition-text",
   "url": null,
   "type": "exhibition-texts",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8mohAAAB4AP4sc%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8mohAAAB4AP4sc%22%29+%5D%5D",
   "tags": ["hard-graft", "delist"],
   "first_publication_date": "2024-09-12T13:07:08+0000",
   "last_publication_date": "2025-05-08T13:44:10+0000",

--- a/pipeline/test/prismic-snapshots/addressables/ZthrZRIAACQALvCC.exhibition-highlight-tours.json
+++ b/pipeline/test/prismic-snapshots/addressables/ZthrZRIAACQALvCC.exhibition-highlight-tours.json
@@ -3,7 +3,7 @@
   "uid": "jason-and-the-adventure-of-254",
   "url": null,
   "type": "exhibition-highlight-tours",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZthrZRIAACQALvCC%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZthrZRIAACQALvCC%22%29+%5D%5D",
   "tags": ["delist"],
   "first_publication_date": "2024-09-16T13:19:23+0000",
   "last_publication_date": "2025-05-12T09:52:55+0000",

--- a/pipeline/test/prismic-snapshots/addressables/aAi4nhEAACMAfdxX.articles.json
+++ b/pipeline/test/prismic-snapshots/addressables/aAi4nhEAACMAfdxX.articles.json
@@ -3,7 +3,7 @@
   "uid": "how-the-slave-trades-medical-legacies-persist",
   "url": null,
   "type": "articles",
-  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJxRfRAAACEAdxqr&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22aAi4nhEAACMAfdxX%22%29+%5D%5D",
+  "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=aJyDARAAAB8Ad2XQ&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22aAi4nhEAACMAfdxX%22%29+%5D%5D",
   "tags": [],
   "first_publication_date": "2025-04-24T10:55:24+0000",
   "last_publication_date": "2025-04-24T11:51:59+0000",

--- a/pipeline/test/transformers/__snapshots__/addressables.test.ts.snap
+++ b/pipeline/test/transformers/__snapshots__/addressables.test.ts.snap
@@ -10,25 +10,20 @@ exports[`addressables transformer transforms articles from Prismic to the expect
         {
           "date": "1803",
           "id": "p4bh9qca",
-          "labels": [
-            "Books",
-            "Online",
-          ],
           "mainContributor": "Collins, Dr.",
           "thumbnailUrl": "https://iiif.wellcomecollection.org/thumbs/b21297563_0007.jp2/full/!200,200/0/default.jpg",
           "title": "Practical rules for the management and medical treatment of Negro slaves, in the sugar colonies / by a professional planter.",
           "type": "Work",
+          "workType": "Books",
         },
         {
           "date": undefined,
           "id": "sgswqhrs",
-          "labels": [
-            "Books",
-          ],
           "mainContributor": "Cartwright, Samuel A.",
           "thumbnailUrl": undefined,
           "title": "Report on the diseases and physical peculiarities of the negro race / Samuel A. Cartwright.",
           "type": "Work",
+          "workType": "Books",
         },
       ],
       "title": "How the slave trade’s medical legacies persist",


### PR DESCRIPTION
## What does this change?

As I was integrating the FE I came across this. One of the issues was how the labels wouldn't wrap and therefore hedge in on the image's space:

<img width="666" height="665" alt="Screenshot 2025-08-13 at 13 17 29" src="https://github.com/user-attachments/assets/9af8b522-0622-48f5-9363-3d12d644d0e3" />

I had a chat with @dana-saur and she quickly opted for removing "Online", only keeping the work type (format).

I thought the change should first come through the API, so this is that.

## How to test



## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? -->

