### PR TITLE
Add daily reindexing scheduler for addressables

### DIFF
--- a/infrastructure/pipeline_stack/scheduled_window_event.tf
+++ b/infrastructure/pipeline_stack/scheduled_window_event.tf
@@ -53,3 +53,21 @@ data "aws_iam_policy_document" "scheduler_invoke_lambda" {
     resources = [module.pipeline_lambda.lambda.arn]
   }
 }
+
+resource "aws_scheduler_schedule" "daily_addressables" {
+  name                = "content-pipeline-daily-addressables-${var.pipeline_date}"
+  schedule_expression = "rate(24 hours)"
+
+  target {
+    arn      = module.pipeline_lambda.lambda.arn
+    role_arn = aws_iam_role.scheduler.arn
+
+    input = jsonencode({
+      contentType = "addressables"
+    })
+  }
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+}


### PR DESCRIPTION
## What does this change?

For https://github.com/wellcomecollection/content-api/issues/265

Adds a new AWS EventBridge scheduler to run daily, reindexing all of the addressables content. 

Ensures all addressables content is fully reprocessed daily, catching any changes to linkedWorks data.

See [handling changes to works](https://github.com/wellcomecollection/docs/tree/main/rfcs/077-enriching-addressables-with-works#handling-changes-to-works) for details.

