### PR TITLE
update graph query to fetch more data

### DIFF
--- a/pipeline/src/graph-queries/addressables/events.ts
+++ b/pipeline/src/graph-queries/addressables/events.ts
@@ -1,3 +1,5 @@
+import { workLinksSlices } from './shared';
+
 const query = `
   events {
     title
@@ -11,6 +13,7 @@ const query = `
           }
         }
       }
+      ${workLinksSlices}
     }
     format {
       title

--- a/pipeline/src/graph-queries/addressables/exhibitions.ts
+++ b/pipeline/src/graph-queries/addressables/exhibitions.ts
@@ -1,6 +1,11 @@
+import { workLinksSlices } from './shared';
+
 const query = `
   exhibitions {
     title
+    body {
+      ${workLinksSlices}
+    }
     format {
       title
     }


### PR DESCRIPTION
## What does this change?

@davidpmccormick reported that, 

"[Zines Forever](https://wellcomecollection.org/exhibitions/zines-forever-diy-publishing-and-disability-justice) has a [featured work link](https://wellcomecollection.org/works/fjkzgmmk) (inside the image gallery) but I don’t see it in the list of linked works from the content api (e.g. https://api.wellcomecollection.org/content/v0/all/Z1hLIxAAAB4AVAWG.exhibitions) – should I expect to?"

We weren't fetching the necessary data for exhibitions and events when querying Prismic, so weren't finding the link. This fixes that.

## How to test
Inside the pipeline folder run:
- `yarn testGraphQuery --type=exhibition`
- `yarn testGraphQuery --type=event`

make sure they return the expected response from Prismic

## How can we measure success?

Exhibitions and Events include linkedWorks when added to the ElasticSearch index

## Have we considered potential risks?

?

