### PR TITLE
Run .org e2es when merging to staging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,6 +125,18 @@ steps:
       - wellcomecollection/aws-assume-role#v0.2.2:
           role: 'arn:aws:iam::756629837203:role/catalogue-ci'
 
+  - wait
+
+  - label: 'E2E Tests: PROD Front-end / STAGE Content API'
+    branches: 'main'
+    trigger: 'experience-e2e'
+    build:
+      env:
+        PLAYWRIGHT_BASE_URL: https://wellcomecollection.org
+        USE_STAGE_APIS: true
+
+  - wait
+
   - block: ':rocket: deploy to prod'
     branches: 'main'
 


### PR DESCRIPTION
## What does this change?

(should) trigger .org e2es after deploying to staging. This ensures our changes do not affect the website before we deploy to production.

## How to test

I don't think we can until we merge? Ideas?

## How can we measure success?

Catches bugs !

## Have we considered potential risks?
N/A