### PR TITLE
format json without  escape characters

### DIFF
--- a/infrastructure/prismic-snapshots/assets_backup_state_machine.tf
+++ b/infrastructure/prismic-snapshots/assets_backup_state_machine.tf
@@ -63,8 +63,8 @@ resource "aws_sfn_state_machine" "assets_backup" {
         Type     = "Task"
         Resource = "arn:aws:states:::aws-sdk:s3:putObject"
         Parameters = {
-          Bucket   = aws_s3_bucket.prismic_backups.bucket
-          Key      = "media-library/latest-asset-snapshot-metadata.json"
+          Bucket = aws_s3_bucket.prismic_backups.bucket
+          Key    = "media-library/latest-asset-snapshot-metadata.json"
           Body = {
             "filename.$"         = "$.metadata.filename"
             "fetch_started_at.$" = "$.metadata.fetch_started_at"


### PR DESCRIPTION
## What does this change?

Alert on the last run of the Prismic asset backup state machine run: https://wellcome.slack.com/archives/CQ720BG02/p1767826910071919
Caused by json encoding on (previous run) upload, which the trigger lambda couldn't read on the next run

Terraform applied

## How to test

The TF has been applied and the state machine executed, twice
See resulting json:
```
{"filename":"prismic-assets-2026-01-08T11:22:55.686Z.json","fetch_started_at":1767871371372}
```

## How can we measure success?

Next run of the state machine is successful 

## Have we considered potential risks?

N/A