### PR TITLE
make comment accurate

### DIFF
--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -100,7 +100,7 @@ export const transformArticle = async (
 
   const format = transformLabelType(document);
 
-  // When we imported data into Prismic from the Wordpress blog captured its original publication date which we want to use as the publication date for articles. If that field isn't present, we fall back to the Prismic document's first publication date.
+  // When we imported data into Prismic from the WordPress blog captured its original publication date which we want to use as the publication date for articles. If that field isn't present, we fall back to the Prismic document's first publication date.
   const datePublished = data.publishDate || firstPublicationDate;
 
   const contributors = getContributors(document);

--- a/pipeline/src/transformers/article.ts
+++ b/pipeline/src/transformers/article.ts
@@ -100,9 +100,7 @@ export const transformArticle = async (
 
   const format = transformLabelType(document);
 
-  // When we imported data into Prismic from the Wordpress blog some content
-  // needed to have its original publication date displayed. It is purely a display
-  // value and does not affect ordering.
+  // When we imported data into Prismic from the Wordpress blog captured its original publication date which we want to use as the publication date for articles. If that field isn't present, we fall back to the Prismic document's first publication date.
   const datePublished = data.publishDate || firstPublicationDate;
 
   const contributors = getContributors(document);


### PR DESCRIPTION
## What does this change?

Updates a comment about publishDates. I think the comment was copied from the wellcomecollection.org article transformer, where it is true, but in the content-api the publishDate is used for ordering

## How to test

N/A

## How can we measure success?

We don't have misleading comments

## Have we considered potential risks?

none