### PR TITLE
Create content indices with zero replicas

### DIFF
--- a/pipeline/src/helpers/elasticsearch.ts
+++ b/pipeline/src/helpers/elasticsearch.ts
@@ -30,7 +30,16 @@ export const ensureIndexExists = async (
   indexConfig: IndexConfig
 ): Promise<void> => {
   try {
-    await elasticClient.indices.create(indexConfig);
+    await elasticClient.indices.create({
+      ...indexConfig,
+      settings: {
+        // The content cluster is a single node, so replicas can never be
+        // allocated; the default of 1 leaves the cluster permanently yellow.
+        // See https://github.com/wellcomecollection/content-api/issues/387
+        number_of_replicas: 0,
+        ...indexConfig.settings,
+      },
+    });
     log.info(`Index '${indexConfig.index}' was created`);
   } catch (e) {
     if (

--- a/pipeline/test/elasticsearch-helpers.test.ts
+++ b/pipeline/test/elasticsearch-helpers.test.ts
@@ -22,7 +22,26 @@ describe('ensureIndexExists', () => {
     } as unknown as ElasticClient;
 
     await ensureIndexExists(client, { index: 'test' });
-    expect(createIndex).toHaveBeenCalledWith({ index: 'test' });
+    expect(createIndex).toHaveBeenCalledWith({
+      index: 'test',
+      settings: { number_of_replicas: 0 },
+    });
+  });
+
+  it('merges index settings with the zero-replicas default', async () => {
+    const createIndex = jest.fn().mockResolvedValue(true);
+    const client = {
+      indices: {
+        create: createIndex,
+      },
+    } as unknown as ElasticClient;
+
+    const testSettings = { analysis: { normalizer: {} } } as const;
+    await ensureIndexExists(client, { index: 'test', settings: testSettings });
+    expect(createIndex).toHaveBeenCalledWith({
+      index: 'test',
+      settings: { number_of_replicas: 0, ...testSettings },
+    });
   });
 
   it('updates the mapping if the index already exists', async () => {
@@ -54,6 +73,7 @@ describe('ensureIndexExists', () => {
     expect(createIndex).toHaveBeenCalledWith({
       index: 'test',
       mappings: testMapping,
+      settings: { number_of_replicas: 0 },
     });
     expect(putMapping).toHaveBeenCalledWith({
       index: 'test',

--- a/pipeline/test/elasticsearch-helpers.test.ts
+++ b/pipeline/test/elasticsearch-helpers.test.ts
@@ -44,6 +44,22 @@ describe('ensureIndexExists', () => {
     });
   });
 
+  it('allows per-index settings to override the zero-replicas default', async () => {
+    const createIndex = jest.fn().mockResolvedValue(true);
+    const client = {
+      indices: {
+        create: createIndex,
+      },
+    } as unknown as ElasticClient;
+
+    const testSettings = { number_of_replicas: 2 } as const;
+    await ensureIndexExists(client, { index: 'test', settings: testSettings });
+    expect(createIndex).toHaveBeenCalledWith({
+      index: 'test',
+      settings: { number_of_replicas: 2 },
+    });
+  });
+
   it('updates the mapping if the index already exists', async () => {
     const createIndex = jest.fn().mockRejectedValue(
       new elasticErrors.ResponseError({


### PR DESCRIPTION
- Closes #387

## What does this change?

The content cluster is intentionally single-node (`zone_count = 1` in `infrastructure/pipeline_stack/elastic_cluster.tf`), so replica shards can never be allocated. The `addressables`/`articles`/`events`/`venues` indices were created without an explicit `number_of_replicas` and so got the Elasticsearch default of 1, leaving the cluster **permanently yellow** — which also forced the logging-cluster Slack alerting (wellcomecollection/platform-infrastructure#495) to special-case this cluster as red-only.

This makes `ensureIndexExists` default `number_of_replicas: 0` in the create-index settings, merged so any per-index `settings` (e.g. the analysis config) are preserved and an explicit per-index replica count would still win. Done centrally rather than per index module because `venues` has no settings export and future indices would inherit the same single-node reality.

## How to test

- `yarn tsc` passes across all workspaces.
- `yarn test` in `pipeline/`: 9 suites, 41 tests pass (on node v20.15.0 per `.nvmrc`; on newer node two suites fail at import with `ReferenceError: ReadableStream is not defined` — pre-existing on `main` and unrelated to this change).
- The updated `ensureIndexExists` tests assert both the zero-replicas default on create and that a per-index `settings` object is merged with the default rather than overwritten.

## Have we considered potential risks?

This only affects **newly created** indices, so it is inert for anything that already exists — no data is touched and no alarm change is required. The live indices keep their current single-replica (yellow) setting until a one-off settings update is applied:

```
PUT /<index>/_settings {"index": {"number_of_replicas": 0}}
```

That backfill for the existing indices is tracked in #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
