### PR TITLE
Ensure extend-zod runs before schema creation

### DIFF
--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -2,7 +2,7 @@ name: Sync OpenAPI spec for developers.wellcomecollection.org
 
 on:
   push:
-    branches: [main, fix-doc-script]
+    branches: [main]
     paths:
       - 'api/src/**'
       - 'common/types/**'

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -2,7 +2,7 @@ name: Sync OpenAPI spec for developers.wellcomecollection.org
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix-doc-script]
     paths:
       - 'api/src/**'
       - 'common/types/**'
@@ -38,7 +38,7 @@ jobs:
         run: yarn install
 
       - name: Generate OpenAPI spec
-        run: npx tsx api/scripts/generate-openapi.ts > /tmp/content.yaml
+        run: npx tsx api/scripts/documentation/generate-openapi.ts > /tmp/content.yaml
 
       - name: Checkout developers.wellcomecollection.org
         uses: actions/checkout@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ Query parameter validation in `api/` is done with Zod schemas, not raw Express t
 - Each list endpoint has a `*QuerySchema` exported from its controller (e.g. `ArticlesQuerySchema`, `EventsQuerySchema`)
 - Shared helpers (`commaSeparatedEnum`, `commaSeparatedPrismicIds`, `dateStringSchema`, `queryStringSchema`, `workIdsSchema`, `PaginationQuerySchema`) live in `api/src/controllers/validation.ts`
 - `ZodError` is caught and converted to the standard `ErrorResponse` JSON shape in `api/src/controllers/error.ts` — do not add separate error handling in controllers
-- When adding a new query parameter, add it to the Zod schema with a `.meta({ description: '...' })` annotation. The OpenAPI generator imports the schema directly, so the parameter appears in the spec automatically. Only touch `api/scripts/generate-openapi.ts` if you're changing response schemas.
+- When adding a new query parameter, add it to the Zod schema with a `.meta({ description: '...' })` annotation. The OpenAPI generator imports the schema directly, so the parameter appears in the spec automatically. Only touch `api/scripts/documentation/generate-openapi.ts` if you're changing response schemas.
 
 ## OpenAPI Spec Generation
 
 The Content API spec is auto-generated and synced to `wellcomecollection/developers.wellcomecollection.org`.
 
-- Generator: `api/scripts/generate-openapi.ts`
-- Run it: `npx tsx api/scripts/generate-openapi.ts` (outputs YAML to stdout)
+- Generator: `api/scripts/documentation/generate-openapi.ts`
+- Run it: `npx tsx api/scripts/documentation/generate-openapi.ts` (outputs YAML to stdout)
 - Sync workflow: `.github/workflows/sync-openapi-spec.yml` — triggers on push to `main` when `api/**` changes
 - **Do not manually edit `reference/content.yaml`** in the developers repo — it is overwritten by the generator
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ The Content API spec is auto-generated and synced to `wellcomecollection/develop
 
 - Generator: `api/scripts/documentation/generate-openapi.ts`
 - Run it: `npx tsx api/scripts/documentation/generate-openapi.ts` (outputs YAML to stdout)
-- Sync workflow: `.github/workflows/sync-openapi-spec.yml` — triggers on push to `main` when `api/**` changes
+- Sync workflow: `.github/workflows/sync-openapi-spec.yml` — triggers on push to `main` when `api/src/**` or `common/types/**` changes
 - **Do not manually edit `reference/content.yaml`** in the developers repo — it is overwritten by the generator
 
 When adding or changing an endpoint, update the generator script to match.

--- a/api/scripts/documentation/extend-zod.ts
+++ b/api/scripts/documentation/extend-zod.ts
@@ -1,0 +1,9 @@
+/**
+ * Side-effect module. Import this before any Zod schemas are created to ensure
+ * extendZodWithOpenApi runs first. In CommonJS (tsx), imports are evaluated in
+ * order, so this must be the first import in any script that uses zod-to-openapi.
+ */
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);

--- a/api/scripts/documentation/generate-openapi.ts
+++ b/api/scripts/documentation/generate-openapi.ts
@@ -1,9 +1,13 @@
 /**
  * Generates the OpenAPI 3.1 spec for the Content API and writes it to stdout.
- * Usage: npx tsx api/scripts/generate-openapi.ts
+ * Usage: npx tsx api/scripts/documentation/generate-openapi.ts
+ *
+ * IMPORTANT: extend-zod must be the very first import. In CommonJS (tsx), imports
+ * are evaluated in order. extendZodWithOpenApi must run before any Zod schemas from
+ * common/ or controllers are created, or those schemas won't have .openapi().
  */
+import './extend-zod';
 import {
-  extendZodWithOpenApi,
   OpenApiGeneratorV31,
   OpenAPIRegistry,
 } from '@asteasolutions/zod-to-openapi';
@@ -41,8 +45,6 @@ import {
   DimensionsSchema as CommonDimensionsSchema,
   ImageSchema as CommonImageSchema,
 } from '@weco/content-common/types/image';
-
-extendZodWithOpenApi(z);
 
 const registry = new OpenAPIRegistry();
 

--- a/common/types/venue.ts
+++ b/common/types/venue.ts
@@ -11,7 +11,6 @@ export type ElasticsearchVenue = {
   };
 };
 
-// Comment to trigger documentation
 export type Venue = {
   type: 'Venue';
   id: string;

--- a/common/types/venue.ts
+++ b/common/types/venue.ts
@@ -11,6 +11,7 @@ export type ElasticsearchVenue = {
   };
 };
 
+// Comment to trigger documentation
 export type Venue = {
   type: 'Venue';
   id: string;


### PR DESCRIPTION
I merged https://github.com/wellcomecollection/content-api/pull/384, but the [action failed](https://github.com/wellcomecollection/content-api/actions/runs/28931003664).

I should've tested the action one last time, because I'd changed enough that it wasn't working anymore. The imports being out of order, it couldn't find what it needed to run properly: `zodSchema.openapi is not a function`. Root cause: in Zod v4, `extendZodWithOpenApi(z)` only patches factory functions created after it runs; schemas created before don't have `.openapi()`. The schemas were being created before the extend call.

This PR fixes it by creating a side-effect module `extend-zod.ts` that must be imported first in `generate-openapi.ts`, so that `extendZodWithOpenApi(z)` can be run before any schemas are required. The scripts are now in `/documentation` to clarify their tight coupling.

I triggered the action here to test it: https://github.com/wellcomecollection/content-api/actions/runs/28932741511/job/85835572519?pr=389 and [it worked](https://github.com/wellcomecollection/developers.wellcomecollection.org/pull/77).