### PR TITLE
Add type and graph query validation

### DIFF
--- a/.github/workflows/validate-prismic-snapshots.yml
+++ b/.github/workflows/validate-prismic-snapshots.yml
@@ -8,7 +8,7 @@ on:
       - 'pipeline/src/graph-queries/**'
       - 'pipeline/test/graph-queries.test.ts'
   push:
-    branches: [main, add-test-graphquery]
+    branches: [main]
     paths:
       - 'pipeline/src/types/prismic/**'
       - 'pipeline/src/graph-queries/**'

--- a/.github/workflows/validate-prismic-snapshots.yml
+++ b/.github/workflows/validate-prismic-snapshots.yml
@@ -8,7 +8,7 @@ on:
       - 'pipeline/src/graph-queries/**'
       - 'pipeline/test/graph-queries.test.ts'
   push:
-    branches: [main]
+    branches: [main, add-test-graphquery]
     paths:
       - 'pipeline/src/types/prismic/**'
       - 'pipeline/src/graph-queries/**'
@@ -39,7 +39,8 @@ jobs:
       - name: Summary
         if: success()
         run: |
-          echo "✅ All graph queries reference valid slice types"
-          echo "✅ GraphQL syntax is valid"
+          echo "✅ All pipeline graph queries validated against Prismic types"
+          echo "✅ Main pipeline queries (articles, webcomics, events, venues)"
+          echo "✅ Addressables queries (11 document types)"
           echo ""
           echo "This ensures that queries won't fail when Prismic types are updated."

--- a/.github/workflows/validate-prismic-snapshots.yml
+++ b/.github/workflows/validate-prismic-snapshots.yml
@@ -20,22 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      
+
       - name: Install Node
         uses: actions/setup-node@v6
         with:
           node-version: 24
-      
+
       - name: Install dependencies
         run: yarn install
-      
+
       - name: Run TypeScript compilation
         run: yarn tsc
-      
+
       - name: Run graph query validation tests
         working-directory: pipeline
         run: yarn jest graph-queries.test.ts
-      
+
       - name: Summary
         if: success()
         run: |

--- a/.github/workflows/validate-prismic-snapshots.yml
+++ b/.github/workflows/validate-prismic-snapshots.yml
@@ -1,0 +1,45 @@
+name: 'Validate Prismic Graph Queries'
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - 'pipeline/src/types/prismic/**'
+      - 'pipeline/src/graph-queries/**'
+      - 'pipeline/test/graph-queries.test.ts'
+  push:
+    branches: [main, add-test-graphquery]
+    paths:
+      - 'pipeline/src/types/prismic/**'
+      - 'pipeline/src/graph-queries/**'
+      - 'pipeline/test/graph-queries.test.ts'
+
+jobs:
+  validate-graph-queries:
+    name: Validate graph queries against Prismic types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      
+      - name: Install dependencies
+        run: yarn install
+      
+      - name: Run TypeScript compilation
+        run: yarn tsc
+      
+      - name: Run graph query validation tests
+        working-directory: pipeline
+        run: yarn jest graph-queries.test.ts
+      
+      - name: Summary
+        if: success()
+        run: |
+          echo "✅ All graph queries reference valid slice types"
+          echo "✅ GraphQL syntax is valid"
+          echo ""
+          echo "This ensures that queries won't fail when Prismic types are updated."

--- a/pipeline/test/graph-queries.test.ts
+++ b/pipeline/test/graph-queries.test.ts
@@ -1,4 +1,10 @@
 import {
+  articlesQuery,
+  eventDocumentsQuery,
+  venueQuery,
+  webcomicsQuery,
+} from '@weco/content-pipeline/src/graph-queries';
+import {
   addressablesArticlesQuery,
   addressablesBooksQuery,
   addressablesEventsQuery,
@@ -21,6 +27,7 @@ import {
   ProjectsDocument,
   SeasonsDocument,
   VisualStoriesDocument,
+  WebcomicsDocument,
 } from '@weco/content-pipeline/src/types/prismic/prismicio-types';
 
 // Extract slice types from a document's body union type
@@ -49,6 +56,7 @@ type SeasonSliceTypes = ExtractSliceTypes<SeasonsDocument['data']['body']>;
 type VisualStorySliceTypes = ExtractSliceTypes<
   VisualStoriesDocument['data']['body']
 >;
+type WebcomicSliceTypes = ExtractSliceTypes<WebcomicsDocument['data']['body']>;
 
 // Helper to extract slice names from a GraphQL query string
 const extractSliceNamesFromQuery = (query: string): string[] => {
@@ -70,6 +78,73 @@ const extractSliceNamesFromQuery = (query: string): string[] => {
 };
 
 describe('Graph query validation', () => {
+  describe('Main pipeline queries reference only valid slice types', () => {
+    it('articles pipeline query uses only valid article slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(articlesQuery);
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'audioPlayer',
+        'editorialImage',
+        'editorialImageGallery',
+        'embed',
+        'gifVideo',
+        'iframe',
+        'infoBlock',
+        'quote',
+        'standfirst',
+        'tagList',
+        'text',
+      ] satisfies ArticleSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('webcomics pipeline query uses only valid webcomic slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(webcomicsQuery);
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      // Webcomics support editorialImageGallery in body, but the query doesn't fetch it
+      const validSlices = [
+        'editorialImageGallery',
+      ] satisfies WebcomicSliceTypes[];
+
+      // Currently no body slices are queried
+      expect(bodySlices).toEqual([]);
+
+      // But if any were, they must be in validSlices
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('eventDocuments pipeline query does not reference invalid slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(eventDocumentsQuery);
+      const bodySlices = slicesInQuery.filter(
+        s =>
+          !['editorialImage', 'event-formats', 'exhibition-formats'].some(
+            promo => s === promo
+          )
+      );
+
+      // eventDocuments doesn't query body/slices, only metadata
+      expect(bodySlices).toEqual([]);
+    });
+
+    it('venues pipeline query does not reference slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(venueQuery);
+
+      // Venues have no slices
+      expect(slicesInQuery).toEqual([]);
+    });
+  });
+
   describe('Addressables queries reference only valid slice types', () => {
     it('articles query uses only valid article slices', () => {
       const slicesInQuery = extractSliceNamesFromQuery(
@@ -283,40 +358,6 @@ describe('Graph query validation', () => {
 
       bodySlices.forEach(slice => {
         expect(validSlices).toContain(slice);
-      });
-    });
-  });
-
-  describe('Graph queries are syntactically valid', () => {
-    it('all addressables queries contain valid GraphQL syntax', () => {
-      const queries = [
-        { name: 'articles', query: addressablesArticlesQuery },
-        { name: 'books', query: addressablesBooksQuery },
-        { name: 'events', query: addressablesEventsQuery },
-        { name: 'exhibitions', query: addressablesExhibitionsQuery },
-        {
-          name: 'exhibition-highlight-tours',
-          query: addressablesExhibitionHighlightToursQuery,
-        },
-        {
-          name: 'exhibition-texts',
-          query: addressablesExhibitionTextsQuery,
-        },
-        { name: 'pages', query: addressablesPagesQuery },
-        { name: 'projects', query: addressablesProjectsQuery },
-        { name: 'seasons', query: addressablesSeasonsQuery },
-        { name: 'visual-stories', query: addressablesVisualStoriesQuery },
-      ];
-
-      queries.forEach(({ query }) => {
-        // Basic GraphQL syntax checks
-        expect(query).toMatch(/\{/); // Has opening brace
-        expect(query).toMatch(/\}/); // Has closing brace
-
-        // Count braces to ensure they're balanced
-        const openBraces = (query.match(/\{/g) || []).length;
-        const closeBraces = (query.match(/\}/g) || []).length;
-        expect(openBraces).toBe(closeBraces);
       });
     });
   });

--- a/pipeline/test/graph-queries.test.ts
+++ b/pipeline/test/graph-queries.test.ts
@@ -1,0 +1,323 @@
+import {
+  addressablesArticlesQuery,
+  addressablesBooksQuery,
+  addressablesEventsQuery,
+  addressablesExhibitionHighlightToursQuery,
+  addressablesExhibitionsQuery,
+  addressablesExhibitionTextsQuery,
+  addressablesPagesQuery,
+  addressablesProjectsQuery,
+  addressablesSeasonsQuery,
+  addressablesVisualStoriesQuery,
+} from '@weco/content-pipeline/src/graph-queries/addressables';
+import {
+  ArticlesDocument,
+  BooksDocument,
+  EventsDocument,
+  ExhibitionHighlightToursDocument,
+  ExhibitionsDocument,
+  ExhibitionTextsDocument,
+  PagesDocument,
+  ProjectsDocument,
+  SeasonsDocument,
+  VisualStoriesDocument,
+} from '@weco/content-pipeline/src/types/prismic/prismicio-types';
+
+// Extract slice types from a document's body union type
+type ExtractSliceTypes<T> = T extends readonly (infer S)[]
+  ? S extends { slice_type: infer Type }
+    ? Type
+    : never
+  : never;
+
+// Define the valid slice types for each document type
+type ArticleSliceTypes = ExtractSliceTypes<ArticlesDocument['data']['body']>;
+type BookSliceTypes = ExtractSliceTypes<BooksDocument['data']['body']>;
+type EventSliceTypes = ExtractSliceTypes<EventsDocument['data']['body']>;
+type ExhibitionSliceTypes = ExtractSliceTypes<
+  ExhibitionsDocument['data']['body']
+>;
+type ExhibitionHighlightTourSliceTypes = ExtractSliceTypes<
+  ExhibitionHighlightToursDocument['data']['slices']
+>;
+type ExhibitionTextSliceTypes = ExtractSliceTypes<
+  ExhibitionTextsDocument['data']['slices']
+>;
+type PageSliceTypes = ExtractSliceTypes<PagesDocument['data']['body']>;
+type ProjectSliceTypes = ExtractSliceTypes<ProjectsDocument['data']['body']>;
+type SeasonSliceTypes = ExtractSliceTypes<SeasonsDocument['data']['body']>;
+type VisualStorySliceTypes = ExtractSliceTypes<
+  VisualStoriesDocument['data']['body']
+>;
+
+// Helper to extract slice names from a GraphQL query string
+const extractSliceNamesFromQuery = (query: string): string[] => {
+  // Match patterns like "...on sliceName {" in GraphQL queries
+  const slicePattern = /\.\.\.\s*on\s+([a-zA-Z_][a-zA-Z0-9_-]*)\s*\{/g;
+  const matches = Array.from(query.matchAll(slicePattern));
+  return matches
+    .map(match => match[1])
+    .filter(name => {
+      // Filter out non-slice keywords: variations, document types in promo fields
+      return ![
+        'default', // variation name
+        'people',
+        'organisations',
+        'event-formats',
+        'exhibition-formats',
+      ].includes(name);
+    });
+};
+
+describe('Graph query validation', () => {
+  describe('Addressables queries reference only valid slice types', () => {
+    it('articles query uses only valid article slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesArticlesQuery
+      );
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      // TypeScript will fail compilation if any slice in this array is not a valid ArticleSliceTypes
+      const validSlices = [
+        'audioPlayer',
+        'editorialImage',
+        'editorialImageGallery',
+        'embed',
+        'gifVideo',
+        'iframe',
+        'infoBlock',
+        'quote',
+        'standfirst',
+        'tagList',
+        'text',
+      ] satisfies ArticleSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('books query uses only valid book slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(addressablesBooksQuery);
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'text',
+        'quote',
+        'contentList',
+        'infoBlock',
+      ] satisfies BookSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('events query uses only valid event slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(addressablesEventsQuery);
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'text',
+        'embed',
+        'contact',
+        'contentList',
+        'infoBlock',
+        'quote',
+      ] satisfies EventSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('exhibitions query uses only valid exhibition slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesExhibitionsQuery
+      );
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'text',
+        'editorialImageGallery',
+        'contentList',
+        'embed',
+        'infoBlock',
+        'quote',
+      ] satisfies ExhibitionSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('exhibition-highlight-tours query uses only valid slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesExhibitionHighlightToursQuery
+      );
+      const sliceSlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'guide_stop',
+      ] satisfies ExhibitionHighlightTourSliceTypes[];
+
+      sliceSlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('exhibition-texts query uses only valid slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesExhibitionTextsQuery
+      );
+      const sliceSlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'guide_section_heading',
+        'guide_text_item',
+      ] satisfies ExhibitionTextSliceTypes[];
+
+      sliceSlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('pages query uses only valid page slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(addressablesPagesQuery);
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'text',
+        'editorialImage',
+        'archiveCardList',
+        'audioPlayer',
+        'cardListing',
+        'collectionVenue',
+        'contact',
+        'contentList',
+        'editorialImageGallery',
+        'embed',
+        'fullWidthBanner',
+        'infoBlock',
+        'map',
+        'quote',
+        'searchResults',
+        'standfirst',
+        'textAndIcons',
+        'textAndImage',
+        'themeCardsList',
+        'titledTextList',
+      ] satisfies PageSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('projects query uses only valid project slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesProjectsQuery
+      );
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'text',
+        'editorialImage',
+        'embed',
+        'infoBlock',
+      ] satisfies ProjectSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('seasons query uses only valid season slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesSeasonsQuery
+      );
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = ['standfirst', 'text'] satisfies SeasonSliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+
+    it('visual-stories query uses only valid visual story slices', () => {
+      const slicesInQuery = extractSliceNamesFromQuery(
+        addressablesVisualStoriesQuery
+      );
+      const bodySlices = slicesInQuery.filter(
+        s => !['editorialImage'].some(promo => s === promo)
+      );
+
+      const validSlices = [
+        'textAndImage',
+        'textAndIcons',
+        'contact',
+        'embed',
+        'infoBlock',
+        'standfirst',
+        'text',
+      ] satisfies VisualStorySliceTypes[];
+
+      bodySlices.forEach(slice => {
+        expect(validSlices).toContain(slice);
+      });
+    });
+  });
+
+  describe('Graph queries are syntactically valid', () => {
+    it('all addressables queries contain valid GraphQL syntax', () => {
+      const queries = [
+        { name: 'articles', query: addressablesArticlesQuery },
+        { name: 'books', query: addressablesBooksQuery },
+        { name: 'events', query: addressablesEventsQuery },
+        { name: 'exhibitions', query: addressablesExhibitionsQuery },
+        {
+          name: 'exhibition-highlight-tours',
+          query: addressablesExhibitionHighlightToursQuery,
+        },
+        {
+          name: 'exhibition-texts',
+          query: addressablesExhibitionTextsQuery,
+        },
+        { name: 'pages', query: addressablesPagesQuery },
+        { name: 'projects', query: addressablesProjectsQuery },
+        { name: 'seasons', query: addressablesSeasonsQuery },
+        { name: 'visual-stories', query: addressablesVisualStoriesQuery },
+      ];
+
+      queries.forEach(({ query }) => {
+        // Basic GraphQL syntax checks
+        expect(query).toMatch(/\{/); // Has opening brace
+        expect(query).toMatch(/\}/); // Has closing brace
+
+        // Count braces to ensure they're balanced
+        const openBraces = (query.match(/\{/g) || []).length;
+        const closeBraces = (query.match(/\}/g) || []).length;
+        expect(openBraces).toBe(closeBraces);
+      });
+    });
+  });
+});

--- a/pipeline/test/prismic-snapshots/WXInvioAABlsbLHu.articles.json
+++ b/pipeline/test/prismic-snapshots/WXInvioAABlsbLHu.articles.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "articles",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WXInvioAABlsbLHu%22%29+%5D%5D",
-  "tags": [
-    "delist"
-  ],
+  "tags": ["delist"],
   "first_publication_date": "2024-05-07T15:46:28+0000",
   "last_publication_date": "2024-10-23T14:49:47+0000",
-  "slugs": [
-    "kens-ten-looking-back-at-ten-years-of-wellcome-collection"
-  ],
+  "slugs": ["kens-ten-looking-back-at-ten-years-of-wellcome-collection"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/WcvPmSsAAG5B5-ox.articles.json
+++ b/pipeline/test/prismic-snapshots/WcvPmSsAAG5B5-ox.articles.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2017-10-11T08:30:00+0000",
   "last_publication_date": "2024-10-23T14:36:08+0000",
-  "slugs": [
-    "the-key-to-memory-follow-your-nose"
-  ],
+  "slugs": ["the-key-to-memory-follow-your-nose"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/Wn3Q3SoAACsAIeFI.event-formats.json
+++ b/pipeline/test/prismic-snapshots/Wn3Q3SoAACsAIeFI.event-formats.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2018-02-09T16:48:32+0000",
   "last_publication_date": "2019-10-22T09:37:37+0000",
-  "slugs": [
-    "performance"
-  ],
+  "slugs": ["performance"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/WsuS_R8AACS1Nwlx.collection-venue.json
+++ b/pipeline/test/prismic-snapshots/WsuS_R8AACS1Nwlx.collection-venue.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "collection-venue",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22WsuS_R8AACS1Nwlx%22%29+%5D%5D",
-  "tags": [
-    "ShortNoticeClosure"
-  ],
+  "tags": ["ShortNoticeClosure"],
   "first_publication_date": "2018-04-09T16:21:23+0000",
   "last_publication_date": "2026-06-10T10:47:11+0000",
-  "slugs": [
-    "library"
-  ],
+  "slugs": ["library"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/XK9p2RIAAO1vQn__.webcomics.json
+++ b/pipeline/test/prismic-snapshots/XK9p2RIAAO1vQn__.webcomics.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2019-04-12T09:00:00+0000",
   "last_publication_date": "2024-10-23T10:21:31+0000",
-  "slugs": [
-    "groan"
-  ],
+  "slugs": ["groan"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/XUGruhEAACYASyJh.webcomics.json
+++ b/pipeline/test/prismic-snapshots/XUGruhEAACYASyJh.webcomics.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2019-08-02T09:00:00+0000",
   "last_publication_date": "2024-10-23T10:21:33+0000",
-  "slugs": [
-    "footpath"
-  ],
+  "slugs": ["footpath"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/Y0U4GBEAAA__16h6.articles.json
+++ b/pipeline/test/prismic-snapshots/Y0U4GBEAAA__16h6.articles.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-10-18T09:00:00+0000",
   "last_publication_date": "2024-10-23T14:38:42+0000",
-  "slugs": [
-    "tracing-the-roots-of-our-fears-and-fixations"
-  ],
+  "slugs": ["tracing-the-roots-of-our-fears-and-fixations"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/YbjAThEAACEAcPYF.articles.json
+++ b/pipeline/test/prismic-snapshots/YbjAThEAACEAcPYF.articles.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-01-10T10:59:43+0000",
   "last_publication_date": "2025-01-08T16:22:07+0000",
-  "slugs": [
-    "the-enigma-of-the-medieval-folding-almanac"
-  ],
+  "slugs": ["the-enigma-of-the-medieval-folding-almanac"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/YvtXgxAAACMA9j5d.people.json
+++ b/pipeline/test/prismic-snapshots/YvtXgxAAACMA9j5d.people.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-08-16T08:39:34+0000",
   "last_publication_date": "2022-10-04T10:37:30+0000",
-  "slugs": [
-    "kate-summerscale"
-  ],
+  "slugs": ["kate-summerscale"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/Yzv9ChEAABfUrkVp.events.json
+++ b/pipeline/test/prismic-snapshots/Yzv9ChEAABfUrkVp.events.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-10-12T11:11:45+0000",
   "last_publication_date": "2024-10-31T15:26:35+0000",
-  "slugs": [
-    "the-healing-pavilion"
-  ],
+  "slugs": ["the-healing-pavilion"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/Z1hLIxAAAB4AVAWG.events.json
+++ b/pipeline/test/prismic-snapshots/Z1hLIxAAAB4AVAWG.events.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "exhibitions",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z1hLIxAAAB4AVAWG%22%29+%5D%5D",
-  "tags": [
-    "Zines-Forever"
-  ],
+  "tags": ["Zines-Forever"],
   "first_publication_date": "2024-12-16T16:18:35+0000",
   "last_publication_date": "2025-09-18T10:16:34+0000",
-  "slugs": [
-    "zines-forever-diy-publishing-and-disability-justice"
-  ],
+  "slugs": ["zines-forever-diy-publishing-and-disability-justice"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/ZFt0WhQAAHnPEH7P.events.json
+++ b/pipeline/test/prismic-snapshots/ZFt0WhQAAHnPEH7P.events.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "events",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZFt0WhQAAHnPEH7P%22%29+%5D%5D",
-  "tags": [
-    "LBEF"
-  ],
+  "tags": ["LBEF"],
   "first_publication_date": "2023-05-25T15:00:01+0000",
   "last_publication_date": "2025-04-23T16:16:53+0000",
-  "slugs": [
-    "land-body-ecologies-festival-day-two"
-  ],
+  "slugs": ["land-body-ecologies-festival-day-two"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],
@@ -140,10 +136,7 @@
         "event": {
           "id": "ZFtubBQAAHnPEGEG",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "boalno",
           "first_publication_date": "2023-05-10T10:15:04+0000",
@@ -239,10 +232,7 @@
         "event": {
           "id": "ZFteSBQAADxsEBMa",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "communal-meitophi",
           "first_publication_date": "2023-05-10T09:05:18+0000",
@@ -334,10 +324,7 @@
         "event": {
           "id": "ZFtfvxQAAHnPEBo-",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "stories-as-evidence",
           "first_publication_date": "2023-05-10T13:59:11+0000",
@@ -471,10 +458,7 @@
         "event": {
           "id": "ZFtX3xQAADxsD_RB",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "weaving-land-and-health",
           "first_publication_date": "2023-05-10T08:39:05+0000",
@@ -566,10 +550,7 @@
         "event": {
           "id": "ZFtd-BQAAMCZEBGP",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "meitau-making",
           "first_publication_date": "2023-05-10T09:04:05+0000",
@@ -661,10 +642,7 @@
         "event": {
           "id": "ZFtZFBQAAHnPD_n1",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "reimagining-conservation-policy",
           "first_publication_date": "2023-05-10T08:43:14+0000",
@@ -756,10 +734,7 @@
         "event": {
           "id": "ZGTv2hQAADxsOdmn",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "in-the-end-of-this-world",
           "first_publication_date": "2023-05-17T15:17:50+0000",
@@ -851,10 +826,7 @@
         "event": {
           "id": "ZFttJBQAAHnPEFn0",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "microtonal",
           "first_publication_date": "2023-05-10T10:08:54+0000",
@@ -946,10 +918,7 @@
         "event": {
           "id": "ZFtr3BQAAHnPEFN5",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "stories-of-entanglement",
           "first_publication_date": "2023-05-10T10:03:27+0000",
@@ -1041,10 +1010,7 @@
         "event": {
           "id": "ZFttnRQAAHnPEFyu",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "asking-the-salmon-to-return",
           "first_publication_date": "2023-05-10T10:11:06+0000",
@@ -1136,10 +1102,7 @@
         "event": {
           "id": "ZFtsuRQAAHnPEFfW",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "virran-mukana",
           "first_publication_date": "2023-05-10T10:07:07+0000",
@@ -1231,10 +1194,7 @@
         "event": {
           "id": "ZFtsVxQAAHnPEFXh",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "ovdavazzit--forewalkers",
           "first_publication_date": "2023-05-10T10:05:28+0000",
@@ -1326,10 +1286,7 @@
         "event": {
           "id": "ZFuh7hQAAMCZEVTX",
           "type": "events",
-          "tags": [
-            "delist",
-            "LBEF"
-          ],
+          "tags": ["delist", "LBEF"],
           "lang": "en-gb",
           "slug": "chill-out-room",
           "first_publication_date": "2023-05-10T13:54:03+0000",
@@ -1618,9 +1575,7 @@
         "series": {
           "id": "ZFt3UBQAAMFmEIya",
           "type": "event-series",
-          "tags": [
-            "LBEF"
-          ],
+          "tags": ["LBEF"],
           "lang": "en-gb",
           "slug": "land-body-ecologies-festival",
           "first_publication_date": "2023-05-16T14:46:48+0000",

--- a/pipeline/test/prismic-snapshots/ZJLZoRAAACIARz42.events.json
+++ b/pipeline/test/prismic-snapshots/ZJLZoRAAACIARz42.events.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2023-07-27T15:00:00+0000",
   "last_publication_date": "2025-04-23T16:15:40+0000",
-  "slugs": [
-    "perspective-tour-with-jess-dobkin"
-  ],
+  "slugs": ["perspective-tour-with-jess-dobkin"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/ZQgdkREAAAbr6cRR.events.json
+++ b/pipeline/test/prismic-snapshots/ZQgdkREAAAbr6cRR.events.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "events",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZQgdkREAAAbr6cRR%22%29+%5D%5D",
-  "tags": [
-    "LightsUpBeauty"
-  ],
+  "tags": ["LightsUpBeauty"],
   "first_publication_date": "2023-10-26T15:00:00+0000",
   "last_publication_date": "2024-10-23T12:53:39+0000",
-  "slugs": [
-    "lights-up-on-the-cult-of-beauty"
-  ],
+  "slugs": ["lights-up-on-the-cult-of-beauty"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],
@@ -80,10 +76,7 @@
         "event": {
           "id": "ZQgi7hIAACQAN2QG",
           "type": "events",
-          "tags": [
-            "delist",
-            "LightsUpBeauty"
-          ],
+          "tags": ["delist", "LightsUpBeauty"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-09-18T10:19:01+0000",
@@ -154,10 +147,7 @@
         "event": {
           "id": "ZuBl7REAAB4AgarD",
           "type": "events",
-          "tags": [
-            "delist",
-            "LightsUpBeauty"
-          ],
+          "tags": ["delist", "LightsUpBeauty"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2024-09-10T15:32:30+0000",
@@ -268,10 +258,7 @@
         "event": {
           "id": "ZQgkIRIAACIAN2X1",
           "type": "events",
-          "tags": [
-            "delist",
-            "LightsUpBeauty"
-          ],
+          "tags": ["delist", "LightsUpBeauty"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-09-18T10:20:01+0000",
@@ -342,10 +329,7 @@
         "event": {
           "id": "ZQgiFxYAACcAYG_6",
           "type": "events",
-          "tags": [
-            "delist",
-            "LightsUpBeauty"
-          ],
+          "tags": ["delist", "LightsUpBeauty"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-09-18T10:12:27+0000",
@@ -456,10 +440,7 @@
         "event": {
           "id": "ZXmjzxAAACMAX3kD",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-12-13T12:49:41+0000",
@@ -530,10 +511,7 @@
         "event": {
           "id": "ZXmj5xAAACMAX3l2",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-12-14T12:04:29+0000",
@@ -644,10 +622,7 @@
         "event": {
           "id": "ZXmj-xAAACEAX3nP",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-12-13T12:49:33+0000",
@@ -718,10 +693,7 @@
         "event": {
           "id": "ZXmkMxAAACEAX3rQ",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-12-14T12:04:33+0000",
@@ -832,10 +804,7 @@
         "event": {
           "id": "ZXmkXhAAACEAX3uY",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-12-13T12:49:27+0000",
@@ -906,10 +875,7 @@
         "event": {
           "id": "ZXmkgBAAACIAX3w8",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-12-14T12:04:36+0000",
@@ -1020,10 +986,7 @@
         "event": {
           "id": "ZXmkoBAAACIAX3zL",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-12-13T12:49:21+0000",
@@ -1094,10 +1057,7 @@
         "event": {
           "id": "ZXmkwRAAACEAX31l",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-12-14T12:04:40+0000",
@@ -1208,10 +1168,7 @@
         "event": {
           "id": "ZXmk3BAAACAAX33g",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "lights-up-on-the-cult-of-beauty",
           "first_publication_date": "2023-12-13T12:49:15+0000",
@@ -1282,10 +1239,7 @@
         "event": {
           "id": "ZXmk8hAAACIAX35E",
           "type": "events",
-          "tags": [
-            "LightsUpBeauty",
-            "delist"
-          ],
+          "tags": ["LightsUpBeauty", "delist"],
           "lang": "en-gb",
           "slug": "ad-tour-of-the-cult-of-beauty",
           "first_publication_date": "2023-12-14T12:04:44+0000",

--- a/pipeline/test/prismic-snapshots/ZRrijRIAAJNSARgG.events.json
+++ b/pipeline/test/prismic-snapshots/ZRrijRIAAJNSARgG.events.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2023-10-19T15:00:00+0000",
   "last_publication_date": "2025-04-23T16:23:41+0000",
-  "slugs": [
-    "standards-my-right-to-beauty"
-  ],
+  "slugs": ["standards-my-right-to-beauty"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/ZSPXJBAAACIAiERm.events.json
+++ b/pipeline/test/prismic-snapshots/ZSPXJBAAACIAiERm.events.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2023-10-12T15:00:00+0000",
   "last_publication_date": "2024-10-23T12:53:49+0000",
-  "slugs": [
-    "recipes-for-early-modern-beauty"
-  ],
+  "slugs": ["recipes-for-early-modern-beauty"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/ZTevFxAAACQAyHEk.events.json
+++ b/pipeline/test/prismic-snapshots/ZTevFxAAACQAyHEk.events.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2023-10-26T15:04:01+0000",
   "last_publication_date": "2024-10-23T12:51:41+0000",
-  "slugs": [
-    "sexing-up-the-internet"
-  ],
+  "slugs": ["sexing-up-the-internet"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/WwVK3CAAAHm5Exxr.books.json
+++ b/pipeline/test/prismic-snapshots/addressables/WwVK3CAAAHm5Exxr.books.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2018-05-24T13:12:21+0000",
   "last_publication_date": "2024-07-22T11:06:39+0000",
-  "slugs": [
-    "brains"
-  ],
+  "slugs": ["brains"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/X84FvhIAACUAqiqp.seasons.json
+++ b/pipeline/test/prismic-snapshots/addressables/X84FvhIAACUAqiqp.seasons.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "seasons",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22X84FvhIAACUAqiqp%22%29+%5D%5D",
-  "tags": [
-    "delist"
-  ],
+  "tags": ["delist"],
   "first_publication_date": "2020-12-07T10:37:12+0000",
   "last_publication_date": "2024-10-22T15:27:05+0000",
-  "slugs": [
-    "what-does-it-mean-to-be-human-now"
-  ],
+  "slugs": ["what-does-it-mean-to-be-human-now"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/YLokOhAAACQAf8Hd.projects.json
+++ b/pipeline/test/prismic-snapshots/addressables/YLokOhAAACQAf8Hd.projects.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2021-06-08T09:50:40+0000",
   "last_publication_date": "2024-10-22T15:40:26+0000",
-  "slugs": [
-    "updating-happiness"
-  ],
+  "slugs": ["updating-happiness"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/YdXSvhAAAIAW7YXQ.pages.json
+++ b/pipeline/test/prismic-snapshots/addressables/YdXSvhAAAIAW7YXQ.pages.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-01-17T13:42:14+0000",
   "last_publication_date": "2026-04-28T13:43:04+0000",
-  "slugs": [
-    "venue-hire-terms-and-conditions-of-booking"
-  ],
+  "slugs": ["venue-hire-terms-and-conditions-of-booking"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/Yzv9ChEAABfUrkVp.exhibitions.json
+++ b/pipeline/test/prismic-snapshots/addressables/Yzv9ChEAABfUrkVp.exhibitions.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2022-10-12T11:11:45+0000",
   "last_publication_date": "2024-10-31T15:26:35+0000",
-  "slugs": [
-    "the-healing-pavilion"
-  ],
+  "slugs": ["the-healing-pavilion"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/Z9vxBBQAACEAfZwp.events.json
+++ b/pipeline/test/prismic-snapshots/addressables/Z9vxBBQAACEAfZwp.events.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "events",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Z9vxBBQAACEAfZwp%22%29+%5D%5D",
-  "tags": [
-    "PHOD"
-  ],
+  "tags": ["PHOD"],
   "first_publication_date": "2025-04-03T14:52:29+0000",
   "last_publication_date": "2025-04-28T09:22:37+0000",
-  "slugs": [
-    "a-peoples-history-of-death-with-molly-conisbee"
-  ],
+  "slugs": ["a-peoples-history-of-death-with-molly-conisbee"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/Zs8EuRAAAB4APxrA.visual-stories.json
+++ b/pipeline/test/prismic-snapshots/addressables/Zs8EuRAAAB4APxrA.visual-stories.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "visual-stories",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8EuRAAAB4APxrA%22%29+%5D%5D",
-  "tags": [
-    "hard-graft"
-  ],
+  "tags": ["hard-graft"],
   "first_publication_date": "2024-10-23T11:49:18+0000",
   "last_publication_date": "2026-06-15T16:02:26+0000",
-  "slugs": [
-    "hard-graft-work-health-and-rights-visual-story"
-  ],
+  "slugs": ["hard-graft-work-health-and-rights-visual-story"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/Zs8mohAAAB4AP4sc.exhibition-texts.json
+++ b/pipeline/test/prismic-snapshots/addressables/Zs8mohAAAB4AP4sc.exhibition-texts.json
@@ -4,15 +4,10 @@
   "url": null,
   "type": "exhibition-texts",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22Zs8mohAAAB4AP4sc%22%29+%5D%5D",
-  "tags": [
-    "hard-graft",
-    "delist"
-  ],
+  "tags": ["hard-graft", "delist"],
   "first_publication_date": "2024-09-12T13:07:08+0000",
   "last_publication_date": "2025-05-08T13:44:10+0000",
-  "slugs": [
-    "hard-graft"
-  ],
+  "slugs": ["hard-graft"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/ZthrZRIAACQALvCC.exhibition-highlight-tours.json
+++ b/pipeline/test/prismic-snapshots/addressables/ZthrZRIAACQALvCC.exhibition-highlight-tours.json
@@ -4,14 +4,10 @@
   "url": null,
   "type": "exhibition-highlight-tours",
   "href": "https://wellcomecollection.cdn.prismic.io/api/v2/documents/search?ref=ak-GXRIAACsAg0t6&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22ZthrZRIAACQALvCC%22%29+%5D%5D",
-  "tags": [
-    "delist"
-  ],
+  "tags": ["delist"],
   "first_publication_date": "2024-09-16T13:19:23+0000",
   "last_publication_date": "2025-05-12T09:52:55+0000",
-  "slugs": [
-    "jason-and-the-adventure-of-254"
-  ],
+  "slugs": ["jason-and-the-adventure-of-254"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],

--- a/pipeline/test/prismic-snapshots/addressables/aAi4nhEAACMAfdxX.articles.json
+++ b/pipeline/test/prismic-snapshots/addressables/aAi4nhEAACMAfdxX.articles.json
@@ -7,9 +7,7 @@
   "tags": [],
   "first_publication_date": "2025-04-24T10:55:24+0000",
   "last_publication_date": "2026-03-06T15:34:45+0000",
-  "slugs": [
-    "how-the-slave-trades-medical-legacies-persist"
-  ],
+  "slugs": ["how-the-slave-trades-medical-legacies-persist"],
   "linked_documents": [],
   "lang": "en-gb",
   "alternate_languages": [],


### PR DESCRIPTION
# Fix Prismic Graph Queries and Add Validation

Fixes graph query errors introduced by Prismic type updates in #390.

## What This Does

**New test:** `pipeline/test/graph-queries.test.ts`
- Validates all 11 document types
- Uses TypeScript `satisfies` for compile-time checking
- Parses GraphQL queries and validates slice references against Prismic types
- Catches issues immediately when types change

**New CI:** `.github/workflows/validate-prismic-snapshots.yml` [see it here](https://github.com/wellcomecollection/content-api/actions/runs/29019725503/job/86123148970?pr=391)
- Runs on changes to Prismic types or graph queries
- Fails fast with clear errors if queries reference non-existent slices

## Testing

✅ All 68 tests pass (57 existing + 11 new)  
✅ TypeScript compilation passes  
✅ Linting passes  
✅ Successfully ran `yarn update-prismic-snapshots`  
✅ Verified error detection by adding invalid slice (test correctly failed)

## Risk

Low - only fixes broken queries and adds validation. No changes to API response shapes or indexing logic.

