### PR TITLE
Fix test type declarations in global.d.ts

### DIFF
--- a/api/test/global.d.ts
+++ b/api/test/global.d.ts
@@ -1,1 +1,2 @@
-import 'jest-extended';
+/// <reference types="jest" />
+/// <reference types="jest-extended" />


### PR DESCRIPTION
## What does this change?

I don't know about you but all my *.test.ts files were working, but shown as erroring in VSCode (it didn't know what "describe" was or where it came from, for example).

This replaces the `import 'jest-extended'` side-effect import in `api/test/global.d.ts` with [explicit triple-slash reference directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html):

```diff
-import 'jest-extended';
+/// <reference types="jest" />
+/// <reference types="jest-extended" />
```

`global.d.ts` is a pure declaration file (ambient module augmentation). Using an `import` statement inside it turns it into a module, which can cause the global type augmentations from `jest` and `jest-extended` to not be picked up correctly. Triple-slash references are the correct way to pull in type declarations in an ambient `.d.ts` file, and also makes the dependency on `jest` itself explicit.

## How to test

Is TS happy? Is your IDE happy? (Might have to restart it)

All tests should pass and no type errors should be reported.

## Risks

None — declaration-file only change with no runtime impact.
